### PR TITLE
Improve error messages with file/chunk context

### DIFF
--- a/minsync/core.py
+++ b/minsync/core.py
@@ -44,6 +44,20 @@ class MinSyncGitError(MinSyncError):
         super().__init__(message, exit_code=2)
 
 
+class MinSyncEmbeddingError(MinSyncError):
+    """Raised when embedding operations fail."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, exit_code=5)
+
+
+class MinSyncVectorStoreError(MinSyncError):
+    """Raised when vector store operations fail."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, exit_code=4)
+
+
 class MinSyncNotImplementedError(MinSyncError):
     """Raised for API methods not yet implemented in this story."""
 
@@ -576,19 +590,48 @@ class MinSync:
             def _flush_pending() -> None:
                 nonlocal chunks_added, chunks_updated, chunks_deleted
                 if pending_texts:
-                    vectors = embedder.embed(pending_texts)
+                    try:
+                        vectors = embedder.embed(pending_texts)
+                    except MinSyncError:
+                        raise
+                    except Exception as exc:
+                        paths = sorted({p for _, _, p in pending_file_ops})
+                        raise MinSyncEmbeddingError(
+                            f"embedding failed while processing {len(pending_texts)} texts "
+                            f"from {len(paths)} file(s) ({', '.join(paths[:3])}"
+                            f"{'...' if len(paths) > 3 else ''}): {exc}"
+                        ) from exc
                     for doc, vector in zip(pending_docs, vectors, strict=False):
                         doc["embedding"] = vector
                 for file_upserts, file_updates, file_path in pending_file_ops:
                     if file_upserts:
-                        vector_store.upsert(file_upserts)
+                        try:
+                            vector_store.upsert(file_upserts)
+                        except MinSyncError:
+                            raise
+                        except Exception as exc:
+                            raise MinSyncVectorStoreError(
+                                f"upsert failed for {file_path} ({len(file_upserts)} chunks): {exc}"
+                            ) from exc
                         chunks_added += len(file_upserts)
                     if file_updates:
-                        vector_store.update(file_updates)
+                        try:
+                            vector_store.update(file_updates)
+                        except MinSyncError:
+                            raise
+                        except Exception as exc:
+                            raise MinSyncVectorStoreError(
+                                f"update failed for {file_path} ({len(file_updates)} chunks): {exc}"
+                            ) from exc
                         chunks_updated += len(file_updates)
-                    removed = vector_store.delete_by_filter(
-                        _stale_path_filter(repo_id, ref_name, file_path, sync_token)
-                    )
+                    try:
+                        removed = vector_store.delete_by_filter(
+                            _stale_path_filter(repo_id, ref_name, file_path, sync_token)
+                        )
+                    except MinSyncError:
+                        raise
+                    except Exception as exc:
+                        raise MinSyncVectorStoreError(f"stale chunk cleanup failed for {file_path}: {exc}") from exc
                     chunks_deleted += int(removed or 0)
                 pending_texts.clear()
                 pending_docs.clear()
@@ -603,13 +646,23 @@ class MinSync:
 
                 if status == "D":
                     _flush_pending()
-                    removed = vector_store.delete_by_filter(_path_filter(repo_id, ref_name, path))
+                    try:
+                        removed = vector_store.delete_by_filter(_path_filter(repo_id, ref_name, path))
+                    except MinSyncError:
+                        raise
+                    except Exception as exc:
+                        raise MinSyncVectorStoreError(f"delete failed for {path}: {exc}") from exc
                     chunks_deleted += int(removed or 0)
                     continue
 
                 file_text = self._read_file_at_commit(repo_root, to_commit, path)
                 normalized = self._normalize_text(file_text, config.get("normalize") or {})
-                chunks = chunker.chunk(normalized, path)
+                try:
+                    chunks = chunker.chunk(normalized, path)
+                except MinSyncError:
+                    raise
+                except Exception as exc:
+                    raise MinSyncError(f"chunking failed for {path}: {exc}") from exc
                 docs = self._build_docs(
                     chunks=chunks,
                     repo_id=repo_id,
@@ -621,7 +674,12 @@ class MinSync:
                 )
 
                 doc_ids = [doc["id"] for doc in docs]
-                existing = vector_store.fetch(doc_ids) if doc_ids else []
+                try:
+                    existing = vector_store.fetch(doc_ids) if doc_ids else []
+                except MinSyncError:
+                    raise
+                except Exception as exc:
+                    raise MinSyncVectorStoreError(f"fetch failed for {path} ({len(doc_ids)} doc IDs): {exc}") from exc
                 existing_ids = {str(doc["id"]) for doc in existing}
 
                 file_upserts: list[dict[str, Any]] = []
@@ -660,8 +718,16 @@ class MinSync:
                     file=sys.stderr,
                 )
 
-            if hasattr(vector_store, "flush"):
-                vector_store.flush()
+            try:
+                if hasattr(vector_store, "flush"):
+                    vector_store.flush()
+            except MinSyncError:
+                raise
+            except Exception as exc:
+                raise MinSyncVectorStoreError(
+                    f"flush failed after processing {chunks_added} added, "
+                    f"{chunks_updated} updated, {chunks_deleted} deleted: {exc}"
+                ) from exc
             self._persist_default_vector_store(repo_root)
 
             cursor_payload = {
@@ -1120,14 +1186,33 @@ class MinSync:
             chunk_schema_id=chunk_schema_id,
         )
 
-        self.vector_store.delete_by_filter(_path_filter(repo_id, ref_name, path))
+        try:
+            self.vector_store.delete_by_filter(_path_filter(repo_id, ref_name, path))
+        except MinSyncError:
+            raise
+        except Exception as exc:
+            raise MinSyncVectorStoreError(f"delete failed during verify --fix for {path}: {exc}") from exc
         if not docs:
             return
 
-        vectors = embedder.embed([doc["text"] for doc in docs])
+        try:
+            vectors = embedder.embed([doc["text"] for doc in docs])
+        except MinSyncError:
+            raise
+        except Exception as exc:
+            raise MinSyncEmbeddingError(
+                f"embedding failed during verify --fix for {path} ({len(docs)} chunks): {exc}"
+            ) from exc
         for doc, vector in zip(docs, vectors, strict=False):
             doc["embedding"] = vector
-        self.vector_store.upsert(docs)
+        try:
+            self.vector_store.upsert(docs)
+        except MinSyncError:
+            raise
+        except Exception as exc:
+            raise MinSyncVectorStoreError(
+                f"upsert failed during verify --fix for {path} ({len(docs)} chunks): {exc}"
+            ) from exc
 
     def _git_commit_exists(self, repo_root: Path, commit: str) -> bool:
         return self._git_repo().commit_exists(commit)

--- a/minsync/core.py
+++ b/minsync/core.py
@@ -594,12 +594,12 @@ class MinSync:
                 nonlocal chunks_added, chunks_updated, chunks_deleted
                 if pending_texts:
                     try:
-                      if effective_max_concurrent > 1 and hasattr(embedder, "async_embed"):
-                          vectors = _parallel_embed_async(
-                              embedder, pending_texts, embed_batch_size, effective_max_concurrent
-                          )
-                      else:
-                          vectors = embedder.embed(pending_texts)
+                        if effective_max_concurrent > 1 and hasattr(embedder, "async_embed"):
+                            vectors = _parallel_embed_async(
+                                embedder, pending_texts, embed_batch_size, effective_max_concurrent
+                            )
+                        else:
+                            vectors = embedder.embed(pending_texts)
                     except MinSyncError:
                         raise
                     except Exception as exc:

--- a/tests/acceptance/test_error_messages.py
+++ b/tests/acceptance/test_error_messages.py
@@ -1,0 +1,187 @@
+"""Tests for improved error messages with file/chunk context (Issue #5).
+
+Verifies that sync and verify operations wrap lower-level exceptions
+(embedding, vectorstore, chunker) into MinSyncError subclasses with
+contextual information (file paths, chunk counts) and correct exit codes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from minsync import MinSync
+from minsync.core import MinSyncEmbeddingError, MinSyncError, MinSyncVectorStoreError
+from tests.conftest import create_test_repo
+from tests.mock_components import (
+    CrashAfterNUpserts,
+    FailingMockChunker,
+    FailingMockEmbedder,
+    MockChunker,
+    MockEmbedder,
+    MockVectorStore,
+)
+
+# ============================================================================
+# Embedding error tests
+# ============================================================================
+
+
+class TestEmbeddingErrors:
+    """Embedding failures during sync should raise MinSyncEmbeddingError."""
+
+    def test_embedding_error_includes_file_context(self, tmp_path: Path) -> None:
+        """Error message must include text count."""
+        repo = create_test_repo(tmp_path)
+        ms = MinSync(
+            repo_path=repo,
+            chunker=MockChunker(),
+            embedder=FailingMockEmbedder(),
+            vector_store=MockVectorStore(),
+        )
+        ms.init()
+
+        with pytest.raises(MinSyncEmbeddingError, match=r"embedding failed.*\d+ texts"):
+            ms.sync()
+
+    def test_embedding_error_exit_code_is_5(self, tmp_path: Path) -> None:
+        """MinSyncEmbeddingError must have exit_code=5."""
+        repo = create_test_repo(tmp_path)
+        ms = MinSync(
+            repo_path=repo,
+            chunker=MockChunker(),
+            embedder=FailingMockEmbedder(),
+            vector_store=MockVectorStore(),
+        )
+        ms.init()
+
+        with pytest.raises(MinSyncEmbeddingError) as exc_info:
+            ms.sync()
+
+        assert exc_info.value.exit_code == 5
+
+
+# ============================================================================
+# VectorStore error tests
+# ============================================================================
+
+
+class TestVectorStoreErrors:
+    """VectorStore failures during sync should raise MinSyncVectorStoreError."""
+
+    def test_vectorstore_upsert_error_includes_file_and_chunk_count(self, tmp_path: Path) -> None:
+        """Error message must include file path and chunk count."""
+        repo = create_test_repo(tmp_path)
+        store = CrashAfterNUpserts(crash_after=0)
+        ms = MinSync(
+            repo_path=repo,
+            chunker=MockChunker(),
+            embedder=MockEmbedder(),
+            vector_store=store,
+        )
+        ms.init()
+
+        with pytest.raises(MinSyncVectorStoreError, match=r"upsert failed for .+\(\d+ chunks\)"):
+            ms.sync()
+
+    def test_vectorstore_error_exit_code_is_4(self, tmp_path: Path) -> None:
+        """MinSyncVectorStoreError must have exit_code=4."""
+        repo = create_test_repo(tmp_path)
+        store = CrashAfterNUpserts(crash_after=0)
+        ms = MinSync(
+            repo_path=repo,
+            chunker=MockChunker(),
+            embedder=MockEmbedder(),
+            vector_store=store,
+        )
+        ms.init()
+
+        with pytest.raises(MinSyncVectorStoreError) as exc_info:
+            ms.sync()
+
+        assert exc_info.value.exit_code == 4
+
+
+# ============================================================================
+# Chunker error tests
+# ============================================================================
+
+
+class TestChunkerErrors:
+    """Chunker failures during sync should raise MinSyncError with file path."""
+
+    def test_chunker_error_includes_file_path(self, tmp_path: Path) -> None:
+        """Error message must include the file path that failed."""
+        repo = create_test_repo(tmp_path)
+        ms = MinSync(
+            repo_path=repo,
+            chunker=FailingMockChunker(),
+            embedder=MockEmbedder(),
+            vector_store=MockVectorStore(),
+        )
+        ms.init()
+
+        with pytest.raises(MinSyncError, match=r"chunking failed for .+"):
+            ms.sync()
+
+
+# ============================================================================
+# Verify --fix error tests
+# ============================================================================
+
+
+class TestVerifyFixErrors:
+    """Errors during verify --fix should include file context."""
+
+    def test_verify_fix_embedding_error_context(self, tmp_path: Path) -> None:
+        """Embedding error during verify --fix must include file path and chunk count."""
+        repo = create_test_repo(tmp_path)
+        store = MockVectorStore()
+        good_embedder = MockEmbedder()
+        ms = MinSync(
+            repo_path=repo,
+            chunker=MockChunker(),
+            embedder=good_embedder,
+            vector_store=store,
+        )
+        ms.init()
+        ms.sync()
+
+        # Corrupt: delete some docs so verify --fix needs to re-embed
+        guide_docs = store.get_docs_by_path("docs/guide.md")
+        assert len(guide_docs) > 0
+        store.direct_delete([d["id"] for d in guide_docs[:2]])
+
+        # Now swap embedder to a failing one
+        ms.embedder = FailingMockEmbedder()
+
+        with pytest.raises(MinSyncEmbeddingError, match=r"embedding failed during verify --fix"):
+            ms.verify(all=True, fix=True)
+
+    def test_verify_fix_vectorstore_error_context(self, tmp_path: Path) -> None:
+        """VectorStore error during verify --fix must include file context."""
+        repo = create_test_repo(tmp_path)
+        store = MockVectorStore()
+        ms = MinSync(
+            repo_path=repo,
+            chunker=MockChunker(),
+            embedder=MockEmbedder(),
+            vector_store=store,
+        )
+        ms.init()
+        ms.sync()
+
+        # Corrupt: delete some docs so verify --fix needs to re-upsert
+        guide_docs = store.get_docs_by_path("docs/guide.md")
+        assert len(guide_docs) > 0
+        store.direct_delete([d["id"] for d in guide_docs[:2]])
+
+        # Monkeypatch upsert to fail
+        def failing_upsert(docs: list[dict]) -> None:
+            raise RuntimeError("Simulated vectorstore failure")
+
+        store.upsert = failing_upsert  # type: ignore[assignment]
+
+        with pytest.raises(MinSyncVectorStoreError, match=r"upsert failed during verify --fix"):
+            ms.verify(all=True, fix=True)

--- a/tests/acceptance/test_integration.py
+++ b/tests/acceptance/test_integration.py
@@ -14,6 +14,7 @@ import subprocess
 import pytest
 
 from minsync import MinSync
+from minsync.core import MinSyncVectorStoreError
 from tests.conftest import (
     SAMPLE_FILES,
     _run_git,
@@ -508,7 +509,7 @@ class TestT42CICDCrashRecovery:
         )
 
         # Attempt sync — should crash
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms_crash.sync()
 
         # Status should show INTERRUPTED (txn.json exists)
@@ -530,7 +531,7 @@ class TestT42CICDCrashRecovery:
             vector_store=crash_vs,
         )
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MinSyncVectorStoreError):
             ms_crash.sync()
 
         # check should still pass (components are healthy)
@@ -554,7 +555,7 @@ class TestT42CICDCrashRecovery:
             vector_store=crash_vs,
         )
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MinSyncVectorStoreError):
             ms_crash.sync()
 
         # Now use a healthy vector store for recovery
@@ -589,7 +590,7 @@ class TestT42CICDCrashRecovery:
             vector_store=crash_vs,
         )
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MinSyncVectorStoreError):
             ms_crash.sync()
 
         recovery_vs = MockVectorStore()
@@ -631,7 +632,7 @@ class TestT42CICDCrashRecovery:
             vector_store=crash_vs,
         )
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MinSyncVectorStoreError):
             ms_crash.sync()
 
         recovery_vs = MockVectorStore()
@@ -664,7 +665,7 @@ class TestT42CICDCrashRecovery:
             vector_store=crash_vs,
         )
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MinSyncVectorStoreError):
             ms_crash.sync()
 
         recovery_vs = MockVectorStore()
@@ -730,7 +731,7 @@ class TestT42CICDCrashRecovery:
             vector_store=crash_vs,
         )
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MinSyncVectorStoreError):
             ms_crash.sync()
 
         recovery_vs = MockVectorStore()

--- a/tests/acceptance/test_parallel_embed.py
+++ b/tests/acceptance/test_parallel_embed.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from minsync.core import MinSyncEmbeddingError
 from tests.mock_components import MockChunker, MockEmbedder, MockVectorStore
 
 # ---------------------------------------------------------------------------
@@ -186,5 +187,5 @@ class TestErrorPropagates:
         ms, _store = _make_minsync(test_repo, embedder=embedder)
         ms.init()
 
-        with pytest.raises(RuntimeError, match="Embedding API error"):
+        with pytest.raises(MinSyncEmbeddingError, match="Embedding API error"):
             ms.sync(max_concurrent=4, batch_size=2)

--- a/tests/acceptance/test_sync_crash.py
+++ b/tests/acceptance/test_sync_crash.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 
 from minsync import MinSync
+from minsync.core import MinSyncVectorStoreError
 from tests.conftest import (
     add_commit,
     create_test_repo,
@@ -96,7 +97,7 @@ class TestT14CrashMidSync:
 
         store.upsert = crashing_upsert
 
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         current_cursor = get_cursor(repo)
@@ -119,7 +120,7 @@ class TestT14CrashMidSync:
 
         store.upsert = crashing_upsert
 
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         txn_path = repo / ".minsync" / "txn.json"
@@ -142,7 +143,7 @@ class TestT14CrashMidSync:
 
         store.upsert = crashing_upsert
 
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         # Restore normal upsert
@@ -168,7 +169,7 @@ class TestT14CrashMidSync:
 
         store.upsert = crashing_upsert
 
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         store.upsert = original_upsert
@@ -195,7 +196,7 @@ class TestT14CrashMidSync:
 
         store.upsert = crashing_upsert
 
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         store.upsert = original_upsert
@@ -221,7 +222,7 @@ class TestT14CrashMidSync:
 
         store.upsert = crashing_upsert
 
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         store.upsert = original_upsert
@@ -260,7 +261,7 @@ class TestT14CrashMidSync:
 
         store.upsert = crashing_upsert
 
-        with pytest.raises(RuntimeError, match="Simulated crash"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         store.upsert = original_upsert
@@ -328,7 +329,7 @@ class TestT15CrashOnFlush:
 
         store.flush = crashing_flush
 
-        with pytest.raises(RuntimeError, match="Simulated crash during flush"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         # Restore normal flush
@@ -370,7 +371,7 @@ class TestT15CrashOnFlush:
 
         store.flush = crashing_flush
 
-        with pytest.raises(RuntimeError, match="Simulated crash during flush"):
+        with pytest.raises(MinSyncVectorStoreError):
             ms.sync()
 
         store.flush = original_flush

--- a/tests/mock_components.py
+++ b/tests/mock_components.py
@@ -256,6 +256,16 @@ class MockVectorStore:
 # ---------------------------------------------------------------------------
 
 
+class FailingMockChunker:
+    """Chunker that always raises on chunk()."""
+
+    def schema_id(self) -> str:
+        return "failing-mock-chunker"
+
+    def chunk(self, text: str, path: str) -> list[Chunk]:
+        raise RuntimeError("Chunker processing failed")
+
+
 class FailingMockEmbedder:
     """Embedder that always raises on every method call."""
 


### PR DESCRIPTION
## Summary
- Add `MinSyncEmbeddingError` (exit_code=5) and `MinSyncVectorStoreError` (exit_code=4) subclasses
- Wrap embedding, vectorstore, and chunker exceptions in `_flush_pending()`, file loop, `_repair_path()`, and `flush()` with contextual info (file path, chunk count, progress)
- CLI exit code spec now enforced during sync/verify (previously only query)
- Add 7 new tests for error messages + update 16 existing crash recovery tests

## Original Issue
하위 레이어 에러(zvec, OpenAI API 등)가 사용자에게 그대로 노출됨. 어떤 파일을 처리하다 실패했는지, 청크가 몇 개였는지 등의 컨텍스트가 없음.

## Test plan
- [x] 7 new tests in `test_error_messages.py` (embedding/vectorstore/chunker/verify-fix errors)
- [x] 16 updated crash recovery tests in `test_sync_crash.py` and `test_integration.py`
- [x] Full suite: 216/216 pass (3 pre-existing T40 CLI failures excluded)

close #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)