### PR TITLE
Auto-retry on transient embedding API errors

### DIFF
--- a/minsync/cli.py
+++ b/minsync/cli.py
@@ -43,6 +43,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-concurrent", type=int, default=None, help="Max parallel embedding API calls (default: from config or 1)."
     )
     sync_parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=None,
+        help="Max retries on transient embedding errors (default: from config or 3).",
+    )
+    sync_parser.add_argument(
         "--wait", action="store_true", help="Wait for lock instead of failing if another sync is running."
     )
     sync_parser.set_defaults(handler=_handle_sync)
@@ -122,6 +128,7 @@ def _handle_sync(ms: MinSync, args: argparse.Namespace) -> int:
         dry_run=args.dry_run,
         batch_size=args.batch_size,
         max_concurrent=args.max_concurrent,
+        max_retries=args.max_retries,
         wait=args.wait,
         verbose=args.verbose,
         quiet=args.quiet,

--- a/minsync/core.py
+++ b/minsync/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import os
@@ -452,6 +453,7 @@ class MinSync:
         dry_run: bool = False,
         batch_size: int | None = None,
         max_concurrent: int | None = None,
+        max_retries: int | None = None,
         wait: bool = False,
         verbose: bool = False,
         quiet: bool = False,
@@ -461,6 +463,9 @@ class MinSync:
         self._ensure_vectorstore(config, repo_root)
         embed_batch_size = batch_size or int((config.get("embedder") or {}).get("batch_size", 64))
         effective_max_concurrent = max_concurrent or int((config.get("embedder") or {}).get("max_concurrent", 1))
+        effective_max_retries = (
+            max_retries if max_retries is not None else int((config.get("embedder") or {}).get("max_retries", 3))
+        )
         minsync_dir = repo_root / ".minsync"
         cursor_path = minsync_dir / "cursor.json"
         txn_path = minsync_dir / "txn.json"
@@ -596,10 +601,20 @@ class MinSync:
                     try:
                         if effective_max_concurrent > 1 and hasattr(embedder, "async_embed"):
                             vectors = _parallel_embed_async(
-                                embedder, pending_texts, embed_batch_size, effective_max_concurrent
+                                embedder,
+                                pending_texts,
+                                embed_batch_size,
+                                effective_max_concurrent,
+                                max_retries=effective_max_retries,
+                                quiet=quiet,
                             )
                         else:
-                            vectors = embedder.embed(pending_texts)
+                            vectors = _embed_with_retry(
+                                embedder.embed,
+                                pending_texts,
+                                max_retries=effective_max_retries,
+                                quiet=quiet,
+                            )
                     except MinSyncError:
                         raise
                     except Exception as exc:
@@ -802,9 +817,9 @@ class MinSync:
         effective_filter = f"{base_filter} AND {normalized_filter}" if normalized_filter else base_filter
 
         try:
-            vectors = embedder.embed([query])
+            vectors = _embed_with_retry(embedder.embed, [query], max_retries=3, quiet=True)
         except Exception as exc:
-            raise MinSyncError(f"embedding failed: {exc}", exit_code=5) from exc
+            raise MinSyncEmbeddingError(f"embedding failed: {exc}") from exc
 
         if not vectors:
             return []
@@ -1205,7 +1220,7 @@ class MinSync:
             return
 
         try:
-            vectors = embedder.embed([doc["text"] for doc in docs])
+            vectors = _embed_with_retry(embedder.embed, [doc["text"] for doc in docs], max_retries=3, quiet=False)
         except MinSyncError:
             raise
         except Exception as exc:
@@ -1706,6 +1721,7 @@ class MinSync:
                 "id": embedder,
                 "batch_size": 64,
                 "max_concurrent": 1,
+                "max_retries": 3,
             },
             "vectorstore": {
                 "id": DEFAULT_VECTORSTORE_ID,
@@ -1726,11 +1742,117 @@ class MinSync:
         path.unlink(missing_ok=True)
 
 
+def _is_transient_error(exc: BaseException) -> bool:
+    """Determine whether *exc* is a transient (retriable) error.
+
+    Uses duck-typing and string matching so we never need to import HTTP
+    libraries directly.
+
+    Returns ``True`` for transient, ``False`` for permanent, and ``True``
+    for unknown errors (retry is the safe default).
+    """
+    # Permanent by exception message -----------------------------------------
+    msg = str(exc).lower()
+    for permanent_phrase in ("invalid api key", "unauthorized", "authentication"):
+        if permanent_phrase in msg:
+            return False
+
+    # Check HTTP status code via duck-typing ----------------------------------
+    status_code: int | None = None
+    raw_code: Any = getattr(exc, "status_code", None)
+    if raw_code is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            status_code = int(raw_code)
+    if status_code is None:
+        resp: Any = getattr(exc, "response", None)
+        if resp is not None:
+            raw_code = getattr(resp, "status_code", None)
+            if raw_code is not None:
+                with contextlib.suppress(TypeError, ValueError):
+                    status_code = int(raw_code)
+
+    if status_code is not None:
+        if status_code in (400, 401, 403, 404, 422):
+            return False
+        if status_code == 429 or status_code >= 500:
+            return True
+
+    # Known transient exception types -----------------------------------------
+    if isinstance(exc, (ConnectionError, TimeoutError, OSError)):
+        return True
+
+    # Transient by exception message ------------------------------------------
+    for transient_phrase in ("rate limit", "timeout", "service unavailable", "429", "503", "502"):
+        if transient_phrase in msg:
+            return True
+
+    # Unknown → treat as transient (retry is safe) ----------------------------
+    return True
+
+
+def _embed_with_retry(
+    embed_fn: Any,
+    texts: list[str],
+    *,
+    max_retries: int = 3,
+    quiet: bool = False,
+) -> list[list[float]]:
+    """Call *embed_fn(texts)* with exponential-backoff retries on transient errors."""
+    last_exc: BaseException | None = None
+    total_attempts = max_retries + 1
+    for attempt in range(1, total_attempts + 1):
+        try:
+            return embed_fn(texts)
+        except Exception as exc:
+            last_exc = exc
+            if not _is_transient_error(exc) or attempt == total_attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 30)
+            if not quiet:
+                print(
+                    f"  embedding failed (attempt {attempt}/{total_attempts}), retrying in {delay:.1f}s: {exc}",
+                    file=sys.stderr,
+                )
+            time.sleep(delay)
+    # Should never reach here, but satisfy type checker
+    raise last_exc  # type: ignore[misc]
+
+
+async def _async_embed_with_retry(
+    async_embed_fn: Any,
+    texts: list[str],
+    *,
+    max_retries: int = 3,
+    quiet: bool = False,
+) -> list[list[float]]:
+    """Async version of :func:`_embed_with_retry`."""
+    last_exc: BaseException | None = None
+    total_attempts = max_retries + 1
+    for attempt in range(1, total_attempts + 1):
+        try:
+            return await async_embed_fn(texts)
+        except Exception as exc:
+            last_exc = exc
+            if not _is_transient_error(exc) or attempt == total_attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 30)
+            if not quiet:
+                print(
+                    f"  embedding failed (attempt {attempt}/{total_attempts}), retrying in {delay:.1f}s: {exc}",
+                    file=sys.stderr,
+                )
+            await asyncio.sleep(delay)
+    raise last_exc  # type: ignore[misc]
+
+
 def _parallel_embed_async(
     embedder: Any,
     texts: list[str],
     sub_batch_size: int,
     max_concurrent: int,
+    *,
+    max_retries: int = 3,
+    quiet: bool = False,
 ) -> list[list[float]]:
     """Run sub-batches of ``embedder.async_embed()`` in parallel via asyncio.
 
@@ -1744,7 +1866,7 @@ def _parallel_embed_async(
 
         async def _embed_batch(batch: list[str]) -> list[list[float]]:
             async with sem:
-                return await embedder.async_embed(batch)
+                return await _async_embed_with_retry(embedder.async_embed, batch, max_retries=max_retries, quiet=quiet)
 
         results = await asyncio.gather(*[_embed_batch(b) for b in sub_batches])
         return [vec for batch_result in results for vec in batch_result]

--- a/minsync/core.py
+++ b/minsync/core.py
@@ -1832,15 +1832,14 @@ async def _async_embed_with_retry(
     quiet: bool = False,
 ) -> list[list[float]]:
     """Async version of :func:`_embed_with_retry`."""
-    async for attempt in AsyncRetrying(
+    retrying = AsyncRetrying(
         retry=retry_if_exception(_is_transient_error),
         stop=stop_after_attempt(max_retries + 1),
         wait=wait_exponential(min=1, max=30),
         reraise=True,
         before_sleep=None if quiet else _make_log_retry(max_retries),
-    ):
-        with attempt:
-            return await async_embed_fn(texts)
+    )
+    return await retrying(async_embed_fn, texts)
 
 
 def _parallel_embed_async(

--- a/minsync/core.py
+++ b/minsync/core.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pygit2
 import yaml
+from tenacity import AsyncRetrying, Retrying, retry_if_exception, stop_after_attempt, wait_exponential
 
 from minsync.gitbackend import GitRepo
 
@@ -1790,6 +1791,21 @@ def _is_transient_error(exc: BaseException) -> bool:
     return True
 
 
+def _make_log_retry(max_retries: int):
+    """Create a *before_sleep* callback that logs retry attempts to stderr."""
+    total = max_retries + 1
+
+    def _log(retry_state):
+        print(
+            f"  embedding failed (attempt {retry_state.attempt_number}/{total}), "
+            f"retrying in {retry_state.next_action.sleep:.1f}s: "
+            f"{retry_state.outcome.exception()}",
+            file=sys.stderr,
+        )
+
+    return _log
+
+
 def _embed_with_retry(
     embed_fn: Any,
     texts: list[str],
@@ -1798,24 +1814,14 @@ def _embed_with_retry(
     quiet: bool = False,
 ) -> list[list[float]]:
     """Call *embed_fn(texts)* with exponential-backoff retries on transient errors."""
-    last_exc: BaseException | None = None
-    total_attempts = max_retries + 1
-    for attempt in range(1, total_attempts + 1):
-        try:
-            return embed_fn(texts)
-        except Exception as exc:
-            last_exc = exc
-            if not _is_transient_error(exc) or attempt == total_attempts:
-                raise
-            delay = min(2 ** (attempt - 1), 30)
-            if not quiet:
-                print(
-                    f"  embedding failed (attempt {attempt}/{total_attempts}), retrying in {delay:.1f}s: {exc}",
-                    file=sys.stderr,
-                )
-            time.sleep(delay)
-    # Should never reach here, but satisfy type checker
-    raise last_exc  # type: ignore[misc]
+    retryer = Retrying(
+        retry=retry_if_exception(_is_transient_error),
+        stop=stop_after_attempt(max_retries + 1),
+        wait=wait_exponential(min=1, max=30),
+        reraise=True,
+        before_sleep=None if quiet else _make_log_retry(max_retries),
+    )
+    return retryer(embed_fn, texts)
 
 
 async def _async_embed_with_retry(
@@ -1826,23 +1832,15 @@ async def _async_embed_with_retry(
     quiet: bool = False,
 ) -> list[list[float]]:
     """Async version of :func:`_embed_with_retry`."""
-    last_exc: BaseException | None = None
-    total_attempts = max_retries + 1
-    for attempt in range(1, total_attempts + 1):
-        try:
+    async for attempt in AsyncRetrying(
+        retry=retry_if_exception(_is_transient_error),
+        stop=stop_after_attempt(max_retries + 1),
+        wait=wait_exponential(min=1, max=30),
+        reraise=True,
+        before_sleep=None if quiet else _make_log_retry(max_retries),
+    ):
+        with attempt:
             return await async_embed_fn(texts)
-        except Exception as exc:
-            last_exc = exc
-            if not _is_transient_error(exc) or attempt == total_attempts:
-                raise
-            delay = min(2 ** (attempt - 1), 30)
-            if not quiet:
-                print(
-                    f"  embedding failed (attempt {attempt}/{total_attempts}), retrying in {delay:.1f}s: {exc}",
-                    file=sys.stderr,
-                )
-            await asyncio.sleep(delay)
-    raise last_exc  # type: ignore[misc]
 
 
 def _parallel_embed_async(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ keywords = ['python']
 dependencies = [
     "pygit2>=1.14.0",
     "pyyaml>=6.0",
+    "tenacity>=8.0.0",
 ]
 requires-python = ">=3.10,<4.0"
 classifiers = [

--- a/tests/acceptance/test_parallel_embed.py
+++ b/tests/acceptance/test_parallel_embed.py
@@ -188,4 +188,4 @@ class TestErrorPropagates:
         ms.init()
 
         with pytest.raises(MinSyncEmbeddingError, match="Embedding API error"):
-            ms.sync(max_concurrent=4, batch_size=2)
+            ms.sync(max_concurrent=4, batch_size=2, max_retries=0)

--- a/tests/acceptance/test_retry.py
+++ b/tests/acceptance/test_retry.py
@@ -1,0 +1,279 @@
+"""Tests for auto-retry on transient embedding API errors (Issue #6).
+
+Covers: _is_transient_error(), _embed_with_retry(), _async_embed_with_retry(),
+sync retry, query retry, verify --fix retry, and --max-retries CLI flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from minsync import MinSync
+from minsync.core import (
+    MinSyncEmbeddingError,
+    _async_embed_with_retry,
+    _embed_with_retry,
+    _is_transient_error,
+)
+from tests.conftest import create_test_repo
+from tests.mock_components import (
+    MockChunker,
+    MockEmbedder,
+    MockVectorStore,
+    PermanentFailEmbedder,
+    TransientFailAsyncEmbedder,
+    TransientFailEmbedder,
+    _HttpLikeError,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level autouse fixture: monkeypatch sleep for instant retries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _instant_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    async def _fast_sleep(delay: float, **kwargs):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+
+# ===========================================================================
+# TestIsTransientError
+# ===========================================================================
+
+
+class TestIsTransientError:
+    def test_connection_error_is_transient(self) -> None:
+        assert _is_transient_error(ConnectionError("connection refused")) is True
+
+    def test_timeout_error_is_transient(self) -> None:
+        assert _is_transient_error(TimeoutError("timed out")) is True
+
+    def test_os_error_is_transient(self) -> None:
+        assert _is_transient_error(OSError("network unreachable")) is True
+
+    def test_429_message_is_transient(self) -> None:
+        assert _is_transient_error(Exception("rate limit exceeded (429)")) is True
+
+    def test_503_message_is_transient(self) -> None:
+        assert _is_transient_error(Exception("service unavailable 503")) is True
+
+    def test_status_code_429_is_transient(self) -> None:
+        exc = _HttpLikeError("too many requests", status_code=429)
+        assert _is_transient_error(exc) is True
+
+    def test_status_code_500_is_transient(self) -> None:
+        exc = _HttpLikeError("internal server error", status_code=500)
+        assert _is_transient_error(exc) is True
+
+    def test_status_code_401_is_permanent(self) -> None:
+        exc = _HttpLikeError("unauthorized", status_code=401)
+        assert _is_transient_error(exc) is False
+
+    def test_status_code_400_is_permanent(self) -> None:
+        exc = _HttpLikeError("bad request", status_code=400)
+        assert _is_transient_error(exc) is False
+
+    def test_invalid_api_key_is_permanent(self) -> None:
+        assert _is_transient_error(Exception("invalid api key")) is False
+
+    def test_unknown_error_treated_as_transient(self) -> None:
+        assert _is_transient_error(Exception("something unexpected")) is True
+
+
+# ===========================================================================
+# TestEmbedWithRetry
+# ===========================================================================
+
+
+class TestEmbedWithRetry:
+    def test_success_on_first_try(self) -> None:
+        embedder = MockEmbedder()
+        result = _embed_with_retry(embedder.embed, ["hello"], max_retries=3)
+        assert len(result) == 1
+        assert embedder.call_count == 1
+
+    def test_transient_failure_then_success(self) -> None:
+        embedder = TransientFailEmbedder(fail_count=2)
+        result = _embed_with_retry(embedder.embed, ["hello"], max_retries=3)
+        assert len(result) == 1
+        assert embedder.call_count == 3  # 2 failures + 1 success
+
+    def test_retries_exhausted_raises(self) -> None:
+        embedder = TransientFailEmbedder(fail_count=10)
+        with pytest.raises(_HttpLikeError, match="rate limit"):
+            _embed_with_retry(embedder.embed, ["hello"], max_retries=2)
+        assert embedder.call_count == 3  # 1 initial + 2 retries
+
+    def test_permanent_error_immediate_raise(self) -> None:
+        embedder = PermanentFailEmbedder()
+        with pytest.raises(_HttpLikeError, match="invalid api key"):
+            _embed_with_retry(embedder.embed, ["hello"], max_retries=3)
+        assert embedder.call_count == 1
+
+    def test_max_retries_zero_no_retry(self) -> None:
+        embedder = TransientFailEmbedder(fail_count=1)
+        with pytest.raises(_HttpLikeError, match="rate limit"):
+            _embed_with_retry(embedder.embed, ["hello"], max_retries=0)
+        assert embedder.call_count == 1
+
+    def test_stderr_progress_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        embedder = TransientFailEmbedder(fail_count=1)
+        _embed_with_retry(embedder.embed, ["hello"], max_retries=3, quiet=False)
+        captured = capsys.readouterr()
+        assert "attempt 1/4" in captured.err
+        assert "retrying in" in captured.err
+
+    def test_quiet_suppresses_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
+        embedder = TransientFailEmbedder(fail_count=1)
+        _embed_with_retry(embedder.embed, ["hello"], max_retries=3, quiet=True)
+        captured = capsys.readouterr()
+        assert "retrying" not in captured.err
+
+
+# ===========================================================================
+# TestAsyncRetry
+# ===========================================================================
+
+
+class TestAsyncRetry:
+    def test_async_transient_retry_success(self) -> None:
+        embedder = TransientFailAsyncEmbedder(fail_count=2)
+        result = asyncio.run(_async_embed_with_retry(embedder.async_embed, ["hello"], max_retries=3))
+        assert len(result) == 1
+
+    def test_async_retries_exhausted(self) -> None:
+        embedder = TransientFailAsyncEmbedder(fail_count=10)
+        with pytest.raises(_HttpLikeError, match="service unavailable"):
+            asyncio.run(_async_embed_with_retry(embedder.async_embed, ["hello"], max_retries=2))
+
+
+# ===========================================================================
+# TestSyncRetry
+# ===========================================================================
+
+
+def _make_minsync(repo: Path, embedder=None):
+    store = MockVectorStore()
+    ms = MinSync(
+        repo_path=repo,
+        chunker=MockChunker(),
+        embedder=embedder or MockEmbedder(),
+        vector_store=store,
+    )
+    return ms, store
+
+
+class TestSyncRetry:
+    def test_sync_transient_then_success(self, tmp_path: Path) -> None:
+        repo = create_test_repo(tmp_path)
+        embedder = TransientFailEmbedder(fail_count=2)
+        ms, _store = _make_minsync(repo, embedder)
+        ms.init()
+        result = ms.sync()
+        assert result.chunks_added > 0
+        assert embedder.call_count >= 3  # at least 2 failures + 1 success
+
+    def test_sync_max_retries_zero_fails(self, tmp_path: Path) -> None:
+        repo = create_test_repo(tmp_path)
+        embedder = TransientFailEmbedder(fail_count=1)
+        ms, _store = _make_minsync(repo, embedder)
+        ms.init()
+        with pytest.raises(MinSyncEmbeddingError):
+            ms.sync(max_retries=0)
+
+    def test_sync_permanent_error_no_retry(self, tmp_path: Path) -> None:
+        repo = create_test_repo(tmp_path)
+        embedder = PermanentFailEmbedder()
+        ms, _store = _make_minsync(repo, embedder)
+        ms.init()
+        with pytest.raises(MinSyncEmbeddingError):
+            ms.sync()
+        assert embedder.call_count == 1
+
+    def test_sync_uses_config_max_retries(self, tmp_path: Path) -> None:
+        """sync() reads max_retries from config when not passed explicitly."""
+        repo = create_test_repo(tmp_path)
+        embedder = TransientFailEmbedder(fail_count=2)
+        ms, _store = _make_minsync(repo, embedder)
+        ms.init()
+        # Default config max_retries=3, so 2 failures should be OK
+        result = ms.sync()
+        assert result.chunks_added > 0
+
+
+# ===========================================================================
+# TestQueryRetry
+# ===========================================================================
+
+
+class TestQueryRetry:
+    def test_query_transient_retry_success(self, tmp_path: Path) -> None:
+        repo = create_test_repo(tmp_path)
+        good_embedder = MockEmbedder()
+        ms, _store = _make_minsync(repo, good_embedder)
+        ms.init()
+        ms.sync()
+
+        # Now swap to a transient-fail embedder for the query
+        transient = TransientFailEmbedder(fail_count=2)
+        ms.embedder = transient
+        results = ms.query("hello")
+        # Should succeed after retries
+        assert isinstance(results, list)
+        assert transient.call_count >= 3
+
+
+# ===========================================================================
+# TestVerifyFixRetry
+# ===========================================================================
+
+
+class TestVerifyFixRetry:
+    def test_verify_fix_transient_retry_success(self, tmp_path: Path) -> None:
+        repo = create_test_repo(tmp_path)
+        good_embedder = MockEmbedder()
+        ms, store = _make_minsync(repo, good_embedder)
+        ms.init()
+        ms.sync()
+
+        # Corrupt: delete some docs so verify --fix needs to re-embed
+        guide_docs = store.get_docs_by_path("docs/guide.md")
+        assert len(guide_docs) > 0
+        store.direct_delete([d["id"] for d in guide_docs[:2]])
+
+        # Swap to transient fail embedder
+        transient = TransientFailEmbedder(fail_count=2)
+        ms.embedder = transient
+        result = ms.verify(all=True, fix=True)
+        assert result.fixed is True
+        assert transient.call_count >= 3
+
+
+# ===========================================================================
+# TestCLIMaxRetries
+# ===========================================================================
+
+
+class TestCLIMaxRetries:
+    def test_max_retries_flag_parsed(self) -> None:
+        from minsync.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["sync", "--max-retries", "5"])
+        assert args.max_retries == 5
+
+    def test_max_retries_default_is_none(self) -> None:
+        from minsync.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["sync"])
+        assert args.max_retries is None

--- a/tests/mock_components.py
+++ b/tests/mock_components.py
@@ -334,6 +334,58 @@ class CrashAfterNUpserts(MockVectorStore):
         super().upsert(docs)
 
 
+# ---------------------------------------------------------------------------
+# Transient / Permanent fail embedders (for retry tests)
+# ---------------------------------------------------------------------------
+
+
+class _HttpLikeError(Exception):
+    """Exception with a status_code attribute for duck-typing."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TransientFailEmbedder(MockEmbedder):
+    """Embedder that fails with a transient 429 error for the first *fail_count* calls."""
+
+    def __init__(self, fail_count: int = 2):
+        super().__init__()
+        self._fail_count = fail_count
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.call_count += 1
+        if self.call_count <= self._fail_count:
+            raise _HttpLikeError("rate limit exceeded", status_code=429)
+        self.total_texts_embedded += len(texts)
+        return [self._text_to_vector(t) for t in texts]
+
+
+class PermanentFailEmbedder(MockEmbedder):
+    """Embedder that always fails with a permanent 401 error."""
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.call_count += 1
+        raise _HttpLikeError("invalid api key", status_code=401)
+
+
+class TransientFailAsyncEmbedder(MockEmbedder):
+    """Embedder whose async_embed fails with transient 503 for the first *fail_count* calls."""
+
+    def __init__(self, fail_count: int = 2):
+        super().__init__()
+        self._fail_count = fail_count
+        self._async_call_count = 0
+
+    async def async_embed(self, texts: list[str]) -> list[list[float]]:
+        self._async_call_count += 1
+        if self._async_call_count <= self._fail_count:
+            raise _HttpLikeError("service unavailable", status_code=503)
+        self.total_texts_embedded += len(texts)
+        return [self._text_to_vector(t) for t in texts]
+
+
 class CrashOnFlush(MockVectorStore):
     """MockVectorStore that raises on the first flush() call (for T15)."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -487,6 +487,7 @@ dependencies = [
     { name = "pygit2", version = "1.18.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pygit2", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyyaml" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -511,6 +512,7 @@ dev = [
 requires-dist = [
     { name = "pygit2", specifier = ">=1.14.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "tenacity", specifier = ">=8.0.0" },
     { name = "zvec", marker = "extra == 'zvec'", specifier = ">=0.2.0" },
 ]
 provides-extras = ["zvec"]
@@ -1193,6 +1195,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add exponential backoff retry for transient embedding API errors (429 rate limit, 5xx, timeout, connection errors) during sync, query, and verify --fix operations. Permanent errors (401 auth, 400 bad request, invalid API key) fail immediately without retry.

- `_is_transient_error()` classifies errors via duck-typing + string matching (no HTTP library imports)
- `_embed_with_retry()` / `_async_embed_with_retry()` with exponential backoff (1s, 2s, 4s... cap 30s)
- `sync()` gains `max_retries` param (resolves from arg → config → default 3)
- `--max-retries` CLI flag on sync subcommand
- 28 new tests covering all retry paths

## Test plan

- [x] All 253 tests pass (`make test`)
- [x] `make check` passes (lint, type checking, deptry)
- [x] `pytest tests/acceptance/test_retry.py -v` — 28 new tests pass

close #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)