### PR TITLE
Add multi-OS CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    name: ci (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.91.0
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo test
+      - run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
           toolchain: 1.91.0
           components: rustfmt, clippy
 
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ github.token }}
+
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3"
 notify-debouncer-full = { version = "0.8.0-rc.2", features = ["tokio"] }
 lzma-sys = { version = "*", features = ["static"] }
 
-[build-dependencies]
+[target.'cfg(not(windows))'.build-dependencies]
 protobuf-src = "2.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ State lives in `.minsync/`. Delete it to start fresh.
 
 ### Vector store
 
-MinSync stores vectors in an embedded [LanceDB](https://github.com/lancedb/lancedb) database (`vectorstore.id = "lancedb"`, the default). The LanceDB build vendors `protoc` automatically (needs a C compiler, standard with rustup).
+MinSync stores vectors in an embedded [LanceDB](https://github.com/lancedb/lancedb) database (`vectorstore.id = "lancedb"`, the default). MinSync vendors `protoc` through `protobuf-src` for its own build script on non-Windows targets; Windows builds and LanceDB's dependency build scripts need a `protoc` binary available on `PATH`.
 
 Set the embedding dimension to match your embedder in `.minsync/config.toml`:
 
@@ -128,10 +128,10 @@ target/
 ## Development
 
 CI assumes the standard GitHub-hosted runners on Ubuntu, macOS, and Windows, with Rust 1.91 installed through rustup.
-The build also expects a working C compiler toolchain, vendored protoc from protobuf-src, LanceDB native dependencies built on CI, and no secrets for normal CI runs.
+The build also expects a working C compiler toolchain, vendored protoc from protobuf-src for MinSync's non-Windows build script, setup-protoc for Windows and LanceDB dependency build scripts, LanceDB native dependencies built on CI, and no secrets for normal CI runs.
 
 ```bash
-cargo test            # 140 tests
+cargo test            # full test suite
 cargo clippy          # lint
 cargo fmt             # format
 ```

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ target/
 
 ## Development
 
+CI assumes the standard GitHub-hosted runners on Ubuntu, macOS, and Windows, with Rust 1.91 installed through rustup.
+The build also expects a working C compiler toolchain, vendored protoc from protobuf-src, LanceDB native dependencies built on CI, and no secrets for normal CI runs.
+
 ```bash
 cargo test            # 140 tests
 cargo clippy          # lint

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,11 @@
 fn main() {
-    // Vendor the protobuf compiler so users don't need system protoc (LanceDB/lance build deps need it).
-    std::env::set_var("PROTOC", protobuf_src::protoc());
+    #[cfg(not(windows))]
+    {
+        std::env::set_var("PROTOC", protobuf_src::protoc());
+    }
+
+    #[cfg(windows)]
+    {
+        println!("cargo:rerun-if-env-changed=PROTOC");
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -91,6 +91,7 @@ impl FileLock {
         let file = std::fs::OpenOptions::new()
             .create(true)
             .truncate(true)
+            .read(true)
             .write(true)
             .open(path)?;
 
@@ -140,7 +141,7 @@ fn atomic_write_json<T: Serialize>(value: &T, path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::io::{Read, Seek, SeekFrom};
 
     fn cursor() -> Cursor {
         Cursor {
@@ -252,9 +253,13 @@ mod tests {
     fn test_filelock_writes_pid() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("lock");
-        let _lock = FileLock::acquire(&path, false).expect("acquire lock");
+        let lock = FileLock::acquire(&path, false).expect("acquire lock");
 
-        let content = fs::read_to_string(&path).expect("read lock content");
+        let mut content = String::new();
+        let mut file = &lock.file;
+        file.seek(SeekFrom::Start(0)).expect("seek lock content");
+        file.read_to_string(&mut content)
+            .expect("read lock content");
 
         assert_eq!(content, std::process::id().to_string());
     }

--- a/tests/ci_contract.rs
+++ b/tests/ci_contract.rs
@@ -16,6 +16,8 @@ fn ci_workflow_defines_required_multi_os_validation() {
         "macos-latest",
         "windows-latest",
         "1.91",
+        "arduino/setup-protoc@v3",
+        "repo-token: ${{ github.token }}",
         "cargo fmt --all -- --check",
         "cargo clippy --all-targets --all-features -- -D warnings",
         "cargo test",
@@ -27,6 +29,17 @@ fn ci_workflow_defines_required_multi_os_validation() {
             "expected workflow to contain {needle:?}"
         );
     }
+
+    let protoc_step = workflow
+        .find("arduino/setup-protoc@v3")
+        .expect("expected workflow to define setup-protoc");
+    let clippy_step = workflow
+        .find("cargo clippy --all-targets --all-features -- -D warnings")
+        .expect("expected workflow to define clippy");
+    assert!(
+        protoc_step < clippy_step,
+        "expected setup-protoc to run before clippy"
+    );
 
     assert!(
         !workflow.contains("secrets."),
@@ -45,6 +58,7 @@ fn readme_documents_supported_ci_assumptions() {
         "Rust 1.91",
         "rustup",
         "C compiler",
+        "setup-protoc",
         "vendored protoc",
         "LanceDB",
         "no secrets",
@@ -54,4 +68,22 @@ fn readme_documents_supported_ci_assumptions() {
             "expected README to contain {needle:?}"
         );
     }
+}
+
+#[test]
+fn windows_ci_uses_setup_protoc_instead_of_vendored_protobuf_src() {
+    let manifest = read_file("Cargo.toml");
+
+    assert!(
+        manifest.contains("[target.'cfg(not(windows))'.build-dependencies]"),
+        "expected protobuf-src build dependency to be disabled on Windows"
+    );
+    assert!(
+        !manifest.contains("\n[build-dependencies]\nprotobuf-src"),
+        "expected protobuf-src not to be an unconditional build dependency"
+    );
+    assert!(
+        manifest.contains("protobuf-src = \"2.1\""),
+        "expected non-Windows builds to keep vendored protobuf-src"
+    );
 }

--- a/tests/ci_contract.rs
+++ b/tests/ci_contract.rs
@@ -1,0 +1,57 @@
+use std::fs;
+
+fn read_file(path: &str) -> String {
+    fs::read_to_string(path).expect(path)
+}
+
+#[test]
+fn ci_workflow_defines_required_multi_os_validation() {
+    let workflow = read_file(".github/workflows/ci.yml");
+
+    for needle in [
+        "pull_request",
+        "push",
+        "main",
+        "ubuntu-latest",
+        "macos-latest",
+        "windows-latest",
+        "1.91",
+        "cargo fmt --all -- --check",
+        "cargo clippy --all-targets --all-features -- -D warnings",
+        "cargo test",
+        "cargo build --release",
+        "Swatinem/rust-cache@v2",
+    ] {
+        assert!(
+            workflow.contains(needle),
+            "expected workflow to contain {needle:?}"
+        );
+    }
+
+    assert!(
+        !workflow.contains("secrets."),
+        "workflow should not reference secrets"
+    );
+}
+
+#[test]
+fn readme_documents_supported_ci_assumptions() {
+    let readme = read_file("README.md");
+
+    for needle in [
+        "Ubuntu",
+        "macOS",
+        "Windows",
+        "Rust 1.91",
+        "rustup",
+        "C compiler",
+        "vendored protoc",
+        "LanceDB",
+        "no secrets",
+    ] {
+        assert!(
+            readme.contains(needle),
+            "expected README to contain {needle:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI for Ubuntu, macOS, and Windows
- Run fmt, clippy with warnings denied, tests, and release build in CI
- Document supported CI OS/toolchain/native dependency assumptions
- Add CI contract tests for the workflow and README assumptions

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build --release

Closes #21