### PR TITLE
Merge dev into main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,12 @@ async fn run(
                         println!("  chunks added:    {}", result.chunks_added);
                         println!("  chunks updated:  {}", result.chunks_updated);
                         println!("  chunks deleted:  {}", result.chunks_deleted);
-                        println!("  elapsed:         {:.2}s", result.elapsed_seconds);
+                        println!();
+                        println!("Sync Stats");
+                        println!("  elapsed time:        {:.2}s", result.elapsed_seconds);
+                        println!("  embedding API calls: {}", result.embedding_api_calls);
+                        println!("  embedded texts:      {}", result.embedded_texts);
+                        println!("  estimated tokens:    {}", result.estimated_tokens);
                     }
                 }
                 OutputFormat::Json => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -264,6 +264,46 @@ async fn test_sync_already_up_to_date() {
 }
 
 #[tokio::test]
+async fn test_sync_reports_embedding_stats() {
+    let (dir, sync, chunker, embedder, mut store) = fixture();
+    write_file(&dir, "a.txt", "alpha beta gamma");
+    write_file(&dir, "b.txt", "delta epsilon zeta");
+    sync.init(false, "openai:text-embedding-3-small", "recursive")
+        .expect("init succeeds");
+
+    let result = sync
+        .sync(&chunker, &embedder, &mut store, true, false, false)
+        .await
+        .expect("full sync succeeds");
+
+    assert!(result.embedding_api_calls > 0);
+    assert_eq!(result.embedded_texts, result.chunks_added);
+    assert!(result.estimated_tokens > 0);
+    assert!(result.elapsed_seconds >= 0.0);
+}
+
+#[tokio::test]
+async fn test_sync_stats_zeroed_when_up_to_date() {
+    let (dir, sync, chunker, embedder, mut store) = fixture();
+    write_file(&dir, "a.txt", "alpha beta gamma");
+    sync.init(false, "openai:text-embedding-3-small", "recursive")
+        .expect("init succeeds");
+    sync.sync(&chunker, &embedder, &mut store, true, false, false)
+        .await
+        .expect("initial sync succeeds");
+
+    let result = sync
+        .sync(&chunker, &embedder, &mut store, false, false, false)
+        .await
+        .expect("second sync succeeds");
+
+    assert!(result.already_up_to_date);
+    assert_eq!(result.embedding_api_calls, 0);
+    assert_eq!(result.embedded_texts, 0);
+    assert_eq!(result.estimated_tokens, 0);
+}
+
+#[tokio::test]
 async fn test_sync_crash_recovery_removes_stale_transaction() {
     let (dir, sync, chunker, embedder, mut store) = fixture();
     write_file(&dir, "a.txt", "alpha beta gamma");


### PR DESCRIPTION
## Summary

Reports embedding statistics in the `minsync sync` command's **text** output, completing the sync-stats feature in the Rust codebase. `SyncResult` already tracked these stats and emitted them in JSON; this adds the human-readable "Sync Stats" block.

## Changes

- Adds a `Sync Stats` block to sync text output: elapsed time, embedding API calls, embedded texts, estimated tokens.
- Stats count only successful embedding calls (incremented after a successful `embed()`).
- Adds integration tests asserting stats are populated on a real sync and zeroed when already up to date.

## Test Plan

- `cargo test` (all suites green, incl. new `test_sync_reports_embedding_stats` and `test_sync_stats_zeroed_when_up_to_date`)
- `cargo fmt --check` and `cargo clippy --all-targets` clean

## Note

The `dev` branch was rebased onto the Rust `main` (the previous Python codebase was replaced by the Rust rewrite). This PR now contains only the Rust sync-stats text-output change.