### PR TITLE
fix(sync): perform initial full sync when no cursor exists

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -108,6 +108,9 @@ async fn sync(
                     result.files_processed_paths.len()
                 );
             } else {
+                if result.initial_sync {
+                    println!("Initial sync: no cursor found — performed full sync.");
+                }
                 println!("Sync complete:");
                 println!("  files processed: {}", result.files_processed);
                 println!("  chunks added:    {}", result.chunks_added);

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum MinSyncError {
     #[error("schema/embedder mismatch — run sync with --full")]
     SchemaMismatch,
 
-    #[error("never synced — run `minsync sync` first")]
+    #[error("never synced — run `minsync sync --full` first")]
     NeverSynced,
 
     #[error("query text is required")]

--- a/src/query.rs
+++ b/src/query.rs
@@ -201,7 +201,12 @@ mod tests {
 
         let result = query(&minsync_dir, "search text", 5, &embedder, &store, None).await;
 
-        assert!(matches!(result, Err(MinSyncError::NeverSynced)));
+        let err = result.expect_err("query without cursor fails");
+        assert!(matches!(err, MinSyncError::NeverSynced));
+        assert!(
+            err.to_string().contains("minsync sync --full"),
+            "error must name the command that resolves the state, got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -68,6 +68,14 @@ impl MinSync {
         let cursor_path = self.minsync_dir.join("cursor.json");
         let manifest_path = self.minsync_dir.join("manifest.json");
 
+        // A cursor-less workspace has never completed an initial sync: its
+        // baseline manifest (written by `init`) cannot drive a meaningful
+        // incremental diff, so upgrade to a full sync. This also guarantees
+        // the `already_up_to_date` early return below is unreachable while
+        // no cursor exists.
+        let initial_sync = !cursor_path.exists();
+        let full = full || initial_sync;
+
         if txn_path.exists() {
             Transaction::remove(&txn_path)?;
         }
@@ -99,6 +107,7 @@ impl MinSync {
                 files_processed_paths,
                 dry_run: true,
                 already_up_to_date: false,
+                initial_sync,
                 ..empty_sync_result(true, false)
             });
         }
@@ -114,6 +123,7 @@ impl MinSync {
 
         let start = std::time::Instant::now();
         let mut result = empty_sync_result(false, false);
+        result.initial_sync = initial_sync;
 
         for change in &changes {
             match change {

--- a/src/sync/result.rs
+++ b/src/sync/result.rs
@@ -19,6 +19,7 @@ pub(super) fn empty_sync_result(dry_run: bool, already_up_to_date: bool) -> Sync
         chunks_deleted: 0,
         dry_run,
         already_up_to_date,
+        initial_sync: false,
         files_processed_paths: Vec::new(),
         elapsed_seconds: 0.0,
         embedding_api_calls: 0,
@@ -52,6 +53,7 @@ mod tests {
         let result = empty_sync_result(true, false);
         assert!(result.dry_run);
         assert!(!result.already_up_to_date);
+        assert!(!result.initial_sync);
         assert_eq!(result.files_processed, 0);
         assert_eq!(result.chunks_added, 0);
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,9 @@ pub struct SyncResult {
     pub chunks_deleted: usize,
     pub dry_run: bool,
     pub already_up_to_date: bool,
+    /// True when this run performed the initial full sync because no
+    /// cursor.json existed (machine-readable readiness state).
+    pub initial_sync: bool,
     pub files_processed_paths: Vec<String>,
     pub elapsed_seconds: f64,
     pub embedding_api_calls: usize,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -277,6 +277,70 @@ async fn test_sync_dry_run_no_side_effects() {
 }
 
 #[tokio::test]
+async fn test_init_then_plain_sync_is_queryable() {
+    // Regression for issue #31: init baselines the manifest, so a plain sync
+    // on a cursor-less workspace must perform the initial full sync instead
+    // of reporting already_up_to_date and leaving the workspace unqueryable.
+    let (dir, sync, chunker, embedder, mut store) = fixture();
+    write_file(&dir, "doc.txt", "alpha beta gamma");
+    sync.init(false, "openai:text-embedding-3-small", "recursive")
+        .expect("init succeeds");
+
+    let result = sync
+        .sync(&chunker, &embedder, &mut store, false, false, false)
+        .await
+        .expect("plain sync succeeds");
+
+    assert!(
+        !result.already_up_to_date,
+        "sync must never report already_up_to_date when no cursor exists"
+    );
+    assert!(
+        result.initial_sync,
+        "sync on a cursor-less workspace must report initial_sync"
+    );
+    assert_eq!(result.files_processed, 1);
+    assert!(result.chunks_added > 0);
+    assert!(
+        dir.path().join(".minsync/cursor.json").exists(),
+        "plain sync on a cursor-less workspace must create cursor.json"
+    );
+
+    let query_results = query(
+        &dir.path().join(".minsync"),
+        "alpha beta",
+        3,
+        &embedder,
+        &store,
+        None,
+    )
+    .await
+    .expect("query immediately after plain sync succeeds");
+    assert!(!query_results.is_empty());
+}
+
+#[tokio::test]
+async fn test_sync_after_initial_sync_is_incremental_not_initial() {
+    let (dir, sync, chunker, embedder, mut store) = fixture();
+    write_file(&dir, "a.txt", "alpha beta gamma");
+    sync.init(false, "openai:text-embedding-3-small", "recursive")
+        .expect("init succeeds");
+    let first = sync
+        .sync(&chunker, &embedder, &mut store, false, false, false)
+        .await
+        .expect("initial sync succeeds");
+    assert!(first.initial_sync);
+
+    let second = sync
+        .sync(&chunker, &embedder, &mut store, false, false, false)
+        .await
+        .expect("second sync succeeds");
+
+    assert!(second.already_up_to_date);
+    assert!(!second.initial_sync);
+}
+
+#[tokio::test]
 async fn test_sync_already_up_to_date() {
     let (dir, sync, chunker, embedder, mut store) = fixture();
     write_file(&dir, "a.txt", "alpha beta gamma");


### PR DESCRIPTION
## Summary

Fixes #31 — `minsync init && minsync sync` on a pre-populated directory exited 0 with `already_up_to_date: true` while never writing `cursor.json`, leaving every query failing as `never synced` and the suggested recovery command looping forever.

## Root cause

`init()` scans existing files into `manifest.json`. `sync(full=false)` then diffed that baseline against the unchanged filesystem and hit the `changes.is_empty() && !full` early return before any cursor was written.

## Fix

- `sync` now detects a missing `cursor.json` and upgrades itself to a full sync — a cursor-less workspace has no meaningful incremental baseline. This makes the `already_up_to_date` early return structurally unreachable while no cursor exists.
- `SyncResult` gains a machine-readable `initial_sync: bool` flag (JSON output), and text mode prints `Initial sync: no cursor found — performed full sync.`
- `NeverSynced` now names `minsync sync --full`, the command that always resolves the state.

## Test plan (TDD)

- RED first: `test_init_then_plain_sync_is_queryable` failed on unchanged code at "sync must never report already_up_to_date when no cursor exists"; GREEN after the fix.
- New regression tests: `test_init_then_plain_sync_is_queryable` (init→plain sync→cursor created→immediately queryable) and `test_sync_after_initial_sync_is_incremental_not_initial` (second sync is `already_up_to_date` + `initial_sync: false`); `test_query_never_synced` now asserts the error names the resolving command.
- Full suite: `cargo test` green (27 integration + all unit tests), `cargo clippy --all-targets` clean, `cargo fmt --check` clean.
- Manual QA with the real binary against a local TEI-compatible stub: `init` → `sync --format json` reported `files_processed: 1, already_up_to_date: false, initial_sync: true`, `cursor.json` created, `query -k 3` returned the document with exit 0.

## Note

`src/sync/mod.rs` was already 382 pure LOC before this change (over the 250 ceiling); this PR adds ~10 lines for the minimal bugfix. Splitting the module is deferred to a dedicated refactor PR to keep this diff reviewable.