### PR TITLE
feat: expose sync and index timing state

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -85,6 +85,29 @@ Sync 출력은 파일 단위 변경과 chunk 단위 저장 결과를 분리합�
 `files added/modified/deleted`는 원본 파일 변경을, `chunks
 inserted/reused/removed`는 content-addressed index row의 삽입·재사용·삭제를
 뜻합니다.
+JSON sync 출력에는 `files_checked`, `elapsed_seconds`,
+`freshness_check_only`, `query_ready`도 포함됩니다. 변경되지 않은 증분
+sync는 content hash 정확성을 위해 workspace를 다시 hash하지만, read,
+chunk, embedding, write, flush, index row rebuild는 수행하지 않고 반환합니다.
+따라서 이때 elapsed time은 freshness-check 비용을 뜻합니다. 변경 sync와
+full sync의 elapsed time에는 indexing과 LanceDB maintenance가 포함됩니다.
+Credential 없이 로컬에서 비교하려면 `cargo run --quiet -- sync --format json`을
+두 번 실행하고, 추적 중인 text 파일 하나를 수정해 다시 실행한 다음
+`cargo run --quiet -- sync --full --format json`을 실행하세요. Query process
+startup 비용은 이 sync 측정에 포함되지 않습니다.
+
+Credential 없이 실행할 수 있는 저장된 scale benchmark는 다음과 같습니다.
+
+```bash
+cargo test --test issue_41_benchmark -- --nocapture
+```
+
+이 benchmark는 동일한 local corpus를 1x, 2x, 4x, 8x로 생성하고 full,
+변경 없음, 파일 변경 sync의 millisecond와 BM25, vector, hybrid 검색의
+p50/p95를 출력합니다. Query scaling과 LanceDB index maintenance를
+분리하기 위해 query 측정은 의도적으로 in-memory store를 사용하며, LanceDB의
+ANN/FTS threshold와 unindexed delta 동작은 live index test가 검증합니다.
+측정값은 관찰 결과이며 machine-specific latency SLO가 아닙니다.
 
 한국어 tokenizer에는 공식 Kiwi native library와 base model이 필요합니다.
 `KIWI_LIBRARY_PATH`는 `libkiwi`, `KIWI_MODEL_PATH`는 압축 해제한

--- a/README.md
+++ b/README.md
@@ -97,6 +97,30 @@ a later sync succeeds.
 Sync output reports file-level changes separately from chunk-level storage
 effects: `files added/modified/deleted` describes source files, while
 `chunks inserted/reused/removed` describes content-addressed index rows.
+JSON sync output also reports `files_checked`, `elapsed_seconds`,
+`freshness_check_only`, and `query_ready`. An unchanged incremental sync
+rehashes the workspace to preserve content-hash correctness, then returns
+without reading, chunking, embedding, writing, flushing, or rebuilding index
+rows; its elapsed time therefore measures freshness-check cost. Changed and
+full syncs include indexing and LanceDB maintenance in their elapsed time.
+For a local, credential-free comparison, run `cargo run --quiet -- sync
+--format json` twice, edit one tracked text file and run it again, then run
+`cargo run --quiet -- sync --full --format json`. Query process startup is
+outside this sync measurement.
+
+Run the checked-in credential-free scale benchmark with:
+
+```bash
+cargo test --test issue_41_benchmark -- --nocapture
+```
+
+It generates the same local corpus at 1x, 2x, 4x, and 8x, reports full,
+unchanged, and changed-file sync milliseconds, and reports p50/p95 for BM25,
+vector, and hybrid retrieval. The benchmark intentionally uses the in-memory
+store, so its query timings measure retrieval scaling separately from LanceDB
+index maintenance; the LanceDB ANN/FTS threshold and unindexed-delta behavior
+are covered by the live index tests. Timing values are observations, not a
+machine-specific latency SLO.
 
 Korean tokenization requires the official Kiwi native library and base model.
 Set `KIWI_LIBRARY_PATH` to `libkiwi` and `KIWI_MODEL_PATH` to the extracted

--- a/src/query.rs
+++ b/src/query.rs
@@ -40,10 +40,7 @@ pub async fn query(
     }
 
     let filter = Filter::And(std::mem::take(&mut filters));
-    let index_state = match mode {
-        QueryMode::Bm25 => None,
-        QueryMode::Vector | QueryMode::Hybrid => store.index_state()?,
-    };
+    let index_state = store.index_state()?;
     let hits = match mode {
         QueryMode::Vector => {
             let query_vec = embedder.embed_query(text).await?;
@@ -111,6 +108,7 @@ pub fn query_text(
         ));
     }
     let filter = Filter::And(vec![Filter::Eq("source_id".to_string(), cursor.source_id)]);
+    let index_state = store.index_state()?;
     Ok(store
         .query_text(text, Some(&filter), k)?
         .into_iter()
@@ -127,7 +125,7 @@ pub fn query_text(
             mode: QueryMode::Bm25.as_str().to_string(),
             vector_rank: None,
             bm25_rank: Some(i + 1),
-            index_state: None,
+            index_state: index_state.clone(),
         })
         .collect())
 }
@@ -229,6 +227,70 @@ mod tests {
 
         async fn embed_query(&self, _text: &str) -> Result<Vec<f32>> {
             Ok(SENTINEL_QUERY_VEC.to_vec())
+        }
+    }
+
+    struct IndexedStore {
+        state: crate::types::IndexState,
+    }
+
+    impl VectorStore for IndexedStore {
+        fn upsert(&mut self, _docs: &[Document]) -> Result<()> {
+            Ok(())
+        }
+
+        fn update(&mut self, _updates: &[crate::vectorstore::DocumentUpdate]) -> Result<()> {
+            Ok(())
+        }
+
+        fn fetch(&self, _ids: &[String]) -> Result<Vec<Document>> {
+            Ok(Vec::new())
+        }
+
+        fn delete_by_filter(&mut self, _filter: &Filter) -> Result<usize> {
+            Ok(0)
+        }
+
+        fn query(
+            &self,
+            _vector: &[f32],
+            _filter: Option<&Filter>,
+            _topk: usize,
+        ) -> Result<Vec<crate::vectorstore::QueryHit>> {
+            Ok(Vec::new())
+        }
+
+        fn query_text(
+            &self,
+            _text: &str,
+            _filter: Option<&Filter>,
+            _topk: usize,
+        ) -> Result<Vec<crate::vectorstore::QueryHit>> {
+            Ok(vec![crate::vectorstore::QueryHit {
+                doc_id: "bm25".to_string(),
+                path: "bm25.txt".to_string(),
+                heading_path: String::new(),
+                chunk_type: "text".to_string(),
+                text: "bm25 result".to_string(),
+                score: 1.0,
+                content_hash: "hash".to_string(),
+            }])
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn doc_count(&self) -> usize {
+            1
+        }
+
+        fn all_paths(&self) -> Vec<String> {
+            vec!["bm25.txt".to_string()]
+        }
+
+        fn index_state(&self) -> Result<Option<crate::types::IndexState>> {
+            Ok(Some(self.state.clone()))
         }
     }
 
@@ -384,6 +446,25 @@ mod tests {
         .expect("query succeeds");
 
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_query_text_reports_index_state() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        write_query_state(&dir, "source-1");
+        let state = crate::types::IndexState {
+            fts_indexed: true,
+            ann_indexed: false,
+            unindexed_rows: None,
+        };
+        let store = IndexedStore {
+            state: state.clone(),
+        };
+
+        let results = query_text(&dir.path().join(".minsync"), "search text", 5, &store, None)
+            .expect("BM25 query succeeds");
+
+        assert_eq!(results[0].index_state, Some(state));
     }
 
     #[tokio::test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -40,6 +40,10 @@ pub async fn query(
     }
 
     let filter = Filter::And(std::mem::take(&mut filters));
+    let index_state = match mode {
+        QueryMode::Bm25 => None,
+        QueryMode::Vector | QueryMode::Hybrid => store.index_state()?,
+    };
     let hits = match mode {
         QueryMode::Vector => {
             let query_vec = embedder.embed_query(text).await?;
@@ -80,6 +84,7 @@ pub async fn query(
             mode: mode.as_str().to_string(),
             vector_rank,
             bm25_rank,
+            index_state: index_state.clone(),
         })
         .collect())
 }
@@ -122,6 +127,7 @@ pub fn query_text(
             mode: QueryMode::Bm25.as_str().to_string(),
             vector_rank: None,
             bm25_rank: Some(i + 1),
+            index_state: None,
         })
         .collect())
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -102,12 +102,17 @@ impl MinSync {
                 .unwrap_or_else(|| Manifest::new(&config.source_id))
         };
         let scan_baseline = if full { None } else { stored_manifest.as_ref() };
+        let start = std::time::Instant::now();
         let new_manifest =
             Manifest::scan_with_baseline(&self.root, &config.source_id, scan_baseline)?;
         let changes = Manifest::diff(&old_manifest, &new_manifest);
 
         if changes.is_empty() && !full {
-            return Ok(empty_sync_result(dry_run, true));
+            let mut result = empty_sync_result(dry_run, true);
+            result.files_checked = new_manifest.files.len();
+            result.query_ready = cursor_path.exists();
+            result.elapsed_seconds = start.elapsed().as_secs_f64();
+            return Ok(result);
         }
 
         if dry_run {
@@ -124,7 +129,7 @@ impl MinSync {
                 .iter()
                 .filter(|change| matches!(change, FileChange::Deleted(_)))
                 .count();
-            return Ok(SyncResult {
+            let mut result = SyncResult {
                 files_processed_paths,
                 files_added,
                 files_modified,
@@ -133,7 +138,10 @@ impl MinSync {
                 already_up_to_date: false,
                 initial_sync,
                 ..empty_sync_result(true, false)
-            });
+            };
+            result.files_checked = new_manifest.files.len();
+            result.elapsed_seconds = start.elapsed().as_secs_f64();
+            return Ok(result);
         }
 
         let sync_token = uuid::Uuid::new_v4().to_string().replace('-', "");
@@ -145,9 +153,10 @@ impl MinSync {
         )
         .save(&txn_path)?;
 
-        let start = std::time::Instant::now();
         let mut result = empty_sync_result(false, false);
         result.initial_sync = initial_sync;
+        result.files_checked = new_manifest.files.len();
+        result.query_ready = true;
         if lexical_rebuild {
             result.chunks_deleted += store.delete_by_filter(&Filter::Eq(
                 "source_id".to_string(),
@@ -475,6 +484,32 @@ mod tests {
 
         assert!(result.already_up_to_date);
         assert_eq!(result.files_processed, 0);
+        assert_eq!(result.files_checked, 1);
+        assert!(result.freshness_check_only);
+        assert!(result.query_ready);
+        assert!(result.elapsed_seconds > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_sync_noop_reports_freshness_check_elapsed_time() {
+        let (dir, sync, chunker, embedder, mut store) = fixture();
+        std::fs::write(dir.path().join("a.txt"), "alpha beta gamma").expect("write file");
+        sync.init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("init succeeds");
+        sync.sync(&chunker, &embedder, &mut store, true, false, false)
+            .await
+            .expect("first sync succeeds");
+
+        let result = sync
+            .sync(&chunker, &embedder, &mut store, false, false, false)
+            .await
+            .expect("no-op sync succeeds");
+
+        assert!(result.already_up_to_date);
+        assert!(
+            result.elapsed_seconds > 0.0,
+            "no-op sync must report freshness-check time"
+        );
     }
 
     #[tokio::test]

--- a/src/sync/result.rs
+++ b/src/sync/result.rs
@@ -28,6 +28,9 @@ pub(super) fn empty_sync_result(dry_run: bool, already_up_to_date: bool) -> Sync
         embedding_api_calls: 0,
         embedded_texts: 0,
         estimated_tokens: 0,
+        files_checked: 0,
+        freshness_check_only: already_up_to_date,
+        query_ready: false,
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,9 @@ pub struct SyncResult {
     pub embedding_api_calls: usize,
     pub embedded_texts: usize,
     pub estimated_tokens: usize,
+    pub files_checked: usize,
+    pub freshness_check_only: bool,
+    pub query_ready: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -44,6 +47,15 @@ pub struct QueryResult {
     pub vector_rank: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bm25_rank: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_state: Option<IndexState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IndexState {
+    pub fts_indexed: bool,
+    pub ann_indexed: bool,
+    pub unindexed_rows: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -72,6 +84,7 @@ pub struct CheckResult {
     pub vectorstore_ok: bool,
     pub all_passed: bool,
     pub errors: Vec<String>,
+    pub index_state: Option<IndexState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -79,6 +92,7 @@ pub struct VerifyResult {
     pub all_passed: bool,
     pub basic_checks: HashMap<String, bool>,
     pub fixed: bool,
+    pub index_state: Option<IndexState>,
 }
 
 #[cfg(test)]

--- a/src/vectorstore/lancedb_store/inner.rs
+++ b/src/vectorstore/lancedb_store/inner.rs
@@ -10,6 +10,7 @@ use super::{
     to_store_error, IndexingConfig, DISTANCE_COLUMN, DISTANCE_TYPE, TABLE_NAME, VECTOR_COLUMN,
 };
 use crate::error::Result;
+use crate::types::IndexState;
 use crate::vectorstore::{Document, DocumentUpdate, Filter, QueryHit};
 use arrow_array::RecordBatch;
 use futures::TryStreamExt;
@@ -267,6 +268,30 @@ impl LanceDbInner {
             .into_iter()
             .map(|index| index.name)
             .collect())
+    }
+
+    pub(super) async fn index_state(&self) -> Result<IndexState> {
+        let indices = self.table.list_indices().await.map_err(to_store_error)?;
+        let fts_indexed = indices
+            .iter()
+            .any(|index| index.columns.iter().any(|column| column == "lexical_text"));
+        let ann = indices
+            .iter()
+            .find(|index| index.columns.iter().any(|column| column == VECTOR_COLUMN));
+        let unindexed_rows = match ann {
+            Some(index) => self
+                .table
+                .index_stats(&index.name)
+                .await
+                .map_err(to_store_error)?
+                .map(|stats| stats.num_unindexed_rows),
+            None => None,
+        };
+        Ok(IndexState {
+            fts_indexed,
+            ann_indexed: ann.is_some(),
+            unindexed_rows,
+        })
     }
 
     pub(super) async fn doc_count(&self) -> Result<usize> {

--- a/src/vectorstore/lancedb_store/mod.rs
+++ b/src/vectorstore/lancedb_store/mod.rs
@@ -18,6 +18,7 @@ pub use filters::filter_to_sql;
 pub use index::IndexingConfig;
 
 use crate::error::{MinSyncError, Result};
+use crate::types::IndexState;
 use crate::vectorstore::{Document, DocumentUpdate, Filter, QueryHit, VectorStore};
 use lancedb::DistanceType;
 use std::path::Path;
@@ -128,6 +129,10 @@ impl LanceDbStore {
         self.request(Command::IndexNames)
     }
 
+    pub fn index_state(&self) -> Result<IndexState> {
+        self.request(Command::IndexState)
+    }
+
     fn request<T>(&self, make: impl FnOnce(Resp<T>) -> Command) -> Result<T> {
         let (resp_tx, resp_rx) = mpsc::channel();
         self.tx.send(make(resp_tx)).map_err(to_store_error)?;
@@ -206,6 +211,10 @@ impl VectorStore for LanceDbStore {
                 Vec::new()
             }
         }
+    }
+
+    fn index_state(&self) -> Result<Option<IndexState>> {
+        LanceDbStore::index_state(self).map(Some)
     }
 }
 

--- a/src/vectorstore/lancedb_store/worker.rs
+++ b/src/vectorstore/lancedb_store/worker.rs
@@ -5,6 +5,7 @@
 use super::inner::LanceDbInner;
 use super::{to_store_error, IndexingConfig};
 use crate::error::Result;
+use crate::types::IndexState;
 use crate::vectorstore::{Document, DocumentUpdate, Filter, QueryHit};
 use std::sync::mpsc;
 
@@ -31,6 +32,7 @@ pub(super) enum Command {
     DocCount(Resp<usize>),
     AllPaths(Resp<Vec<String>>),
     IndexNames(Resp<Vec<String>>),
+    IndexState(Resp<IndexState>),
     Shutdown,
 }
 
@@ -92,6 +94,7 @@ pub(super) fn run_worker(
             Command::DocCount(resp) => send_response(resp, rt.block_on(inner.doc_count())),
             Command::AllPaths(resp) => send_response(resp, rt.block_on(inner.all_paths())),
             Command::IndexNames(resp) => send_response(resp, rt.block_on(inner.index_names())),
+            Command::IndexState(resp) => send_response(resp, rt.block_on(inner.index_state())),
             Command::Shutdown => break,
         }
     }

--- a/src/vectorstore/mod.rs
+++ b/src/vectorstore/mod.rs
@@ -3,6 +3,7 @@ pub mod memory;
 pub mod similarity;
 
 use crate::error::Result;
+use crate::types::IndexState;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,6 +57,9 @@ pub trait VectorStore: Send + Sync {
     fn flush(&mut self) -> Result<()>;
     fn doc_count(&self) -> usize;
     fn all_paths(&self) -> Vec<String>;
+    fn index_state(&self) -> Result<Option<IndexState>> {
+        Ok(None)
+    }
 }
 
 use crate::config::Config;

--- a/src/verify/health.rs
+++ b/src/verify/health.rs
@@ -32,11 +32,13 @@ pub async fn check(
         let _ = store.doc_count();
         true
     };
+    let index_state = store.index_state()?;
 
     Ok(CheckResult {
         embedder_ok,
         vectorstore_ok,
         all_passed: embedder_ok && vectorstore_ok && errors.is_empty(),
         errors,
+        index_state,
     })
 }

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -56,6 +56,7 @@ pub async fn verify(
     );
 
     let manifest = Manifest::scan(root, &config.source_id)?;
+    let index_state = store.index_state()?;
     let stale_paths = find_stale_paths(&manifest, store);
     basic_checks.insert("no_stale_paths".to_string(), stale_paths.is_empty());
 
@@ -89,6 +90,7 @@ pub async fn verify(
         all_passed: basic_checks.values().all(|passed| *passed),
         basic_checks,
         fixed,
+        index_state,
     })
 }
 

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -56,7 +56,6 @@ pub async fn verify(
     );
 
     let manifest = Manifest::scan(root, &config.source_id)?;
-    let index_state = store.index_state()?;
     let stale_paths = find_stale_paths(&manifest, store);
     basic_checks.insert("no_stale_paths".to_string(), stale_paths.is_empty());
 
@@ -69,6 +68,7 @@ pub async fn verify(
     } else {
         false
     };
+    let index_state = store.index_state()?;
 
     let mut sample_ok = true;
     for path in sample_paths(&manifest, sample) {
@@ -136,11 +136,78 @@ mod tests {
     use crate::sync::MinSync;
     use crate::types::SyncState;
     use crate::vectorstore::memory::InMemoryStore;
-    use crate::vectorstore::Document;
+    use crate::vectorstore::{Document, DocumentUpdate, QueryHit};
     use async_trait::async_trait;
     use tempfile::TempDir;
 
     struct MockEmbedder;
+
+    struct StateTrackingStore {
+        inner: InMemoryStore,
+        before_repair: crate::types::IndexState,
+        after_repair: crate::types::IndexState,
+        repaired: bool,
+    }
+
+    impl VectorStore for StateTrackingStore {
+        fn upsert(&mut self, docs: &[Document]) -> Result<()> {
+            self.inner.upsert(docs)
+        }
+
+        fn update(&mut self, updates: &[DocumentUpdate]) -> Result<()> {
+            self.inner.update(updates)
+        }
+
+        fn fetch(&self, ids: &[String]) -> Result<Vec<Document>> {
+            self.inner.fetch(ids)
+        }
+
+        fn delete_by_filter(&mut self, filter: &Filter) -> Result<usize> {
+            let deleted = self.inner.delete_by_filter(filter)?;
+            if deleted > 0 {
+                self.repaired = true;
+            }
+            Ok(deleted)
+        }
+
+        fn query(
+            &self,
+            vector: &[f32],
+            filter: Option<&Filter>,
+            topk: usize,
+        ) -> Result<Vec<QueryHit>> {
+            self.inner.query(vector, filter, topk)
+        }
+
+        fn query_text(
+            &self,
+            text: &str,
+            filter: Option<&Filter>,
+            topk: usize,
+        ) -> Result<Vec<QueryHit>> {
+            self.inner.query_text(text, filter, topk)
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            self.inner.flush()
+        }
+
+        fn doc_count(&self) -> usize {
+            self.inner.doc_count()
+        }
+
+        fn all_paths(&self) -> Vec<String> {
+            self.inner.all_paths()
+        }
+
+        fn index_state(&self) -> Result<Option<crate::types::IndexState>> {
+            Ok(Some(if self.repaired {
+                self.after_repair.clone()
+            } else {
+                self.before_repair.clone()
+            }))
+        }
+    }
 
     #[async_trait]
     impl Embedder for MockEmbedder {
@@ -333,5 +400,62 @@ mod tests {
         assert!(result.all_passed);
         assert!(result.fixed);
         assert_eq!(store.all_paths(), vec!["a.txt"]);
+    }
+
+    #[tokio::test]
+    async fn test_verify_fix_reports_post_repair_index_state() {
+        let (dir, sync, chunker, embedder, mut store) = fixture();
+        std::fs::write(dir.path().join("a.txt"), "alpha beta gamma").expect("write file");
+        sync.init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("init succeeds");
+        sync.sync(&chunker, &embedder, &mut store, true, false, false)
+            .await
+            .expect("sync succeeds");
+        let config = Config::load(&dir.path().join(".minsync/config.toml")).expect("load config");
+        store
+            .upsert(&[Document {
+                id: "stale".to_string(),
+                embedding: vec![0.0; 8],
+                text: "stale".to_string(),
+                source_id: config.source_id,
+                path: "deleted.txt".to_string(),
+                chunk_schema_id: chunker.schema_id().to_string(),
+                chunk_type: "text".to_string(),
+                heading_path: String::new(),
+                content_hash: "stale".to_string(),
+                seen_token: "old".to_string(),
+            }])
+            .expect("upsert stale doc");
+
+        let before_repair = crate::types::IndexState {
+            fts_indexed: true,
+            ann_indexed: true,
+            unindexed_rows: Some(1),
+        };
+        let after_repair = crate::types::IndexState {
+            fts_indexed: true,
+            ann_indexed: true,
+            unindexed_rows: Some(0),
+        };
+        let mut tracking_store = StateTrackingStore {
+            inner: store,
+            before_repair: before_repair.clone(),
+            after_repair: after_repair.clone(),
+            repaired: false,
+        };
+
+        let result = verify(
+            &dir.path().join(".minsync"),
+            dir.path(),
+            &chunker,
+            &mut tracking_store,
+            true,
+            None,
+        )
+        .await
+        .expect("verify succeeds");
+
+        assert!(result.fixed);
+        assert_eq!(result.index_state, Some(after_repair));
     }
 }

--- a/tests/issue_41_benchmark.rs
+++ b/tests/issue_41_benchmark.rs
@@ -1,0 +1,182 @@
+use async_trait::async_trait;
+use minsync::chunker::chonkie::ChonkieChunker;
+use minsync::cli::QueryMode;
+use minsync::embedder::Embedder;
+use minsync::error::Result;
+use minsync::query::query;
+use minsync::sync::MinSync;
+use minsync::vectorstore::memory::InMemoryStore;
+use minsync::vectorstore::{Document, VectorStore};
+use std::time::Instant;
+
+struct LocalEmbedder;
+
+#[async_trait]
+impl Embedder for LocalEmbedder {
+    fn id(&self) -> &str {
+        "local:issue-41"
+    }
+
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|text| vector_for(text)).collect())
+    }
+
+    async fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
+        Ok(vector_for(text))
+    }
+}
+
+fn vector_for(text: &str) -> Vec<f32> {
+    let digest = minsync::id::content_hash(text);
+    digest
+        .as_bytes()
+        .iter()
+        .take(8)
+        .map(|byte| *byte as f32 / 255.0)
+        .collect()
+}
+
+fn percentile(samples: &mut [f64], percentile: f64) -> f64 {
+    samples.sort_by(f64::total_cmp);
+    let index = ((samples.len() - 1) as f64 * percentile).round() as usize;
+    samples[index]
+}
+
+async fn measure_sync(
+    sync: &MinSync,
+    chunker: &ChonkieChunker,
+    embedder: &LocalEmbedder,
+    store: &mut InMemoryStore,
+    full: bool,
+) -> f64 {
+    let started = Instant::now();
+    sync.sync(chunker, embedder, store, full, false, false)
+        .await
+        .expect("local benchmark sync succeeds");
+    started.elapsed().as_secs_f64() * 1_000.0
+}
+
+fn seed_documents(store: &mut InMemoryStore, scale: usize, source_id: &str) {
+    let documents: Vec<_> = (0..scale * 8)
+        .map(|index| Document {
+            id: format!("doc-{index}"),
+            embedding: vector_for(&format!("document {index} selective")),
+            text: format!("document {index} selective benchmark text"),
+            source_id: source_id.to_string(),
+            path: format!("doc-{index}.txt"),
+            chunk_schema_id: "benchmark".to_string(),
+            chunk_type: "text".to_string(),
+            heading_path: String::new(),
+            content_hash: format!("hash-{index}"),
+            seen_token: "benchmark".to_string(),
+        })
+        .collect();
+    store.upsert(&documents).expect("seed benchmark documents");
+}
+
+#[tokio::test]
+async fn issue_41_local_benchmark_reports_sync_and_query_scaling() {
+    let embedder = LocalEmbedder;
+    let chunker = ChonkieChunker::new(128, "\n ");
+    let mut rows = Vec::new();
+
+    for scale in [1_usize, 2, 4, 8] {
+        let root = tempfile::tempdir().expect("create benchmark root");
+        for index in 0..scale * 8 {
+            std::fs::write(
+                root.path().join(format!("doc-{index}.txt")),
+                format!("document {index} selective benchmark text"),
+            )
+            .expect("write benchmark document");
+        }
+        let sync = MinSync::new(root.path().to_path_buf());
+        sync.init(false, "local:issue-41", "chonkie")
+            .expect("initialize benchmark workspace");
+        let mut store = InMemoryStore::new();
+
+        let full_ms = measure_sync(&sync, &chunker, &embedder, &mut store, true).await;
+        let noop_ms = measure_sync(&sync, &chunker, &embedder, &mut store, false).await;
+        std::fs::write(
+            root.path().join("doc-0.txt"),
+            "changed selective benchmark text",
+        )
+        .expect("modify benchmark document");
+        let changed_ms = measure_sync(&sync, &chunker, &embedder, &mut store, false).await;
+
+        let source_id = minsync::state::Cursor::load(&root.path().join(".minsync/cursor.json"))
+            .expect("load benchmark cursor")
+            .source_id;
+        seed_documents(&mut store, scale, &source_id);
+        let mut query_samples = [Vec::new(), Vec::new(), Vec::new()];
+        for _ in 0..5 {
+            let started = Instant::now();
+            query(
+                &root.path().join(".minsync"),
+                "selective",
+                5,
+                &embedder,
+                &store,
+                None,
+                QueryMode::Bm25,
+            )
+            .await
+            .expect("BM25 benchmark query succeeds");
+            query_samples[0].push(started.elapsed().as_secs_f64() * 1_000.0);
+
+            let started = Instant::now();
+            query(
+                &root.path().join(".minsync"),
+                "selective",
+                5,
+                &embedder,
+                &store,
+                None,
+                QueryMode::Vector,
+            )
+            .await
+            .expect("vector benchmark query succeeds");
+            query_samples[1].push(started.elapsed().as_secs_f64() * 1_000.0);
+
+            let started = Instant::now();
+            query(
+                &root.path().join(".minsync"),
+                "selective",
+                5,
+                &embedder,
+                &store,
+                None,
+                QueryMode::Hybrid,
+            )
+            .await
+            .expect("hybrid benchmark query succeeds");
+            query_samples[2].push(started.elapsed().as_secs_f64() * 1_000.0);
+        }
+
+        rows.push(serde_json::json!({
+            "scale": scale,
+            "documents": scale * 8,
+            "sync_ms": {
+                "full": full_ms,
+                "unchanged": noop_ms,
+                "changed_file": changed_ms
+            },
+            "query_ms_p50": {
+                "bm25": percentile(&mut query_samples[0], 0.50),
+                "vector": percentile(&mut query_samples[1], 0.50),
+                "hybrid": percentile(&mut query_samples[2], 0.50)
+            },
+            "query_ms_p95": {
+                "bm25": percentile(&mut query_samples[0], 0.95),
+                "vector": percentile(&mut query_samples[1], 0.95),
+                "hybrid": percentile(&mut query_samples[2], 0.95)
+            },
+            "backend": "in_memory",
+            "index_state": "not_applicable"
+        }));
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&rows).expect("serialize benchmark report")
+    );
+}


### PR DESCRIPTION
## Summary

Closes #41.

- Measure and expose the full freshness-check duration for unchanged syncs.
- Report `files_checked`, `freshness_check_only`, and `query_ready` in sync JSON.
- Expose LanceDB FTS/ANN/unindexed-row state through query, check, and verify results.
- Add a credential-free 1x/2x/4x/8x benchmark covering full, unchanged, and changed-file sync plus BM25, vector, and hybrid p50/p95 retrieval timings.
- Document the freshness-check boundary, index thresholds, and reproducible benchmark command.

## Acceptance coverage

- Unchanged sync still hashes files for manifest correctness but skips read, chunk,
  embed, write, flush, and index rebuild work.
- Existing LanceDB FTS/ANN maintenance remains unchanged; this PR adds observability
  rather than a second search implementation or AutoRAG fingerprint.
- AutoRAG-only sidecar fingerprints, path mapping, parsed-mirror staging, caches,
  and retrieval orchestration are intentionally out of scope.

## Verification

```text
RED:
cargo test test_sync_noop_reports_freshness_check_elapsed_time -- --nocapture
failed because unchanged sync returned elapsed_seconds=0.0.

GREEN:
cargo test sync::tests::test_sync_noop_reports_freshness_check_elapsed_time -- --nocapture
passed after timing was moved before manifest scanning.

cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-targets
cargo build --all-targets
```

All final validation commands passed: 200 unit tests, 2 BM25 CLI tests, 8
contract tests, 31 integration tests, and the issue benchmark.

Benchmark command:

```bash
cargo test --test issue_41_benchmark -- --nocapture
```

Observed local results (milliseconds; machine-specific observations, not SLO):

| Scale | Documents | Full | Unchanged | Changed file |
|---:|---:|---:|---:|---:|
| 1x | 8 | 18.170 | 1.092 | 15.770 |
| 2x | 16 | 18.539 | 1.662 | 18.262 |
| 4x | 32 | 19.150 | 1.649 | 18.811 |
| 8x | 64 | 20.264 | 2.000 | 17.772 |

The same command prints BM25/vector/hybrid p50 and p95 timings for each scale.
The benchmark uses the in-memory store intentionally to isolate retrieval
scaling from LanceDB maintenance; live LanceDB threshold/index correctness
tests remain in the existing suite.
