### PR TITLE
perf(manifest): skip unchanged file rehashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3853,6 +3853,7 @@ dependencies = [
  "chrono",
  "chunk",
  "clap",
+ "filetime",
  "fs2",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ protobuf-src = "2.1"
 
 [dev-dependencies]
 tempfile = "3"
+filetime = "0.2"
 assert_cmd = "2"
 predicates = "3"
 wiremock = "0.6"

--- a/README.ko.md
+++ b/README.ko.md
@@ -87,8 +87,9 @@ inserted/reused/removed`는 content-addressed index row의 삽입·재사용·�
 뜻합니다.
 JSON sync 출력에는 `files_checked`, `elapsed_seconds`,
 `freshness_check_only`, `query_ready`도 포함됩니다. 변경되지 않은 증분
-sync는 content hash 정확성을 위해 workspace를 다시 hash하지만, read,
-chunk, embedding, write, flush, index row rebuild는 수행하지 않고 반환합니다.
+sync는 보수적인 metadata fingerprint로 변경 없는 파일의 재해시를 건너뛴 뒤,
+read, chunk, embedding, write, flush, index row rebuild는 수행하지 않고
+반환합니다.
 따라서 이때 elapsed time은 freshness-check 비용을 뜻합니다. 변경 sync와
 full sync의 elapsed time에는 indexing과 LanceDB maintenance가 포함됩니다.
 Credential 없이 로컬에서 비교하려면 `cargo run --quiet -- sync --format json`을

--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ effects: `files added/modified/deleted` describes source files, while
 `chunks inserted/reused/removed` describes content-addressed index rows.
 JSON sync output also reports `files_checked`, `elapsed_seconds`,
 `freshness_check_only`, and `query_ready`. An unchanged incremental sync
-rehashes the workspace to preserve content-hash correctness, then returns
-without reading, chunking, embedding, writing, flushing, or rebuilding index
-rows; its elapsed time therefore measures freshness-check cost. Changed and
+uses a conservative metadata fingerprint to skip hashing unchanged files,
+then returns without reading, chunking, embedding, writing, flushing, or
+rebuilding index rows; its elapsed time therefore measures freshness-check
+cost. Changed and
 full syncs include indexing and LanceDB maintenance in their elapsed time.
 For a local, credential-free comparison, run `cargo run --quiet -- sync
 --format json` twice, edit one tracked text file and run it again, then run

--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ State lives in `.minsync/`:
 
 Delete `.minsync/` to start fresh.
 
+### Freshness checks
+
+After the first completed sync, MinSync uses the persisted file metadata
+fingerprint as a conservative fast path. On Unix this fingerprint includes
+size, modification time, change time, device, and inode, so unchanged files
+reuse their manifest hash without reading their contents. A replacement that
+keeps the same size and restores the modification time still changes the
+fingerprint through the filesystem change time and is rehashed.
+
+Manifests written by older versions, platforms without the required metadata,
+and explicit `minsync sync --full` scans conservatively hash file contents.
+The fast path is not a second freshness owner: the manifest remains the only
+source of content hashes, and a fingerprint mismatch always falls back to
+SHA-256. Filesystem writers that mutate content after metadata is observed
+remain subject to the normal concurrent-write race; run `--full` when an
+authoritative rescan is required.
+
 ## Chunkers
 
 | id | Strategy | Boundary stability under edits |

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -371,6 +371,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_scan_with_baseline_reuses_matching_fingerprint_without_hashing() {
         let dir = tempfile::tempdir().expect("create tempdir");
@@ -387,6 +388,28 @@ mod tests {
         );
         assert_eq!(stats.files_rehashed, 0);
         assert_eq!(stats.bytes_hashed, 0);
+        assert_eq!(stats.files_examined, 1);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn test_scan_with_baseline_rehashes_when_fingerprint_unavailable() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        fs::write(dir.path().join("a.txt"), "alpha").expect("write file");
+        let baseline = Manifest::scan(dir.path(), "source-1").expect("scan baseline");
+
+        let (manifest, stats) =
+            Manifest::scan_with_baseline_stats(dir.path(), "source-1", Some(&baseline))
+                .expect("scan with baseline");
+
+        assert_eq!(
+            manifest.files["a.txt"].content_hash,
+            baseline.files["a.txt"].content_hash
+        );
+        assert!(baseline.files["a.txt"].fingerprint.is_none());
+        assert!(manifest.files["a.txt"].fingerprint.is_none());
+        assert_eq!(stats.files_rehashed, 1);
+        assert_eq!(stats.bytes_hashed, 5);
         assert_eq!(stats.files_examined, 1);
     }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -23,6 +23,15 @@ pub struct ManifestFileEntry {
     pub size: u64,
     pub mtime_ns: u128,
     pub content_hash: String,
+    #[serde(default)]
+    pub fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScanStats {
+    pub files_examined: usize,
+    pub files_rehashed: usize,
+    pub bytes_hashed: u64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -49,9 +58,18 @@ impl Manifest {
     pub fn scan_with_baseline(
         root: &Path,
         source_id: &str,
-        _baseline: Option<&Manifest>,
+        baseline: Option<&Manifest>,
     ) -> Result<Self> {
+        Self::scan_with_baseline_stats(root, source_id, baseline).map(|(manifest, _)| manifest)
+    }
+
+    pub fn scan_with_baseline_stats(
+        root: &Path,
+        source_id: &str,
+        baseline: Option<&Manifest>,
+    ) -> Result<(Self, ScanStats)> {
         let mut manifest = Self::new(source_id);
+        let mut stats = ScanStats::default();
         let walker = WalkBuilder::new(root)
             .add_custom_ignore_filename(".minsyncignore")
             .hidden(false)
@@ -68,6 +86,7 @@ impl Manifest {
                 continue;
             }
 
+            stats.files_examined += 1;
             let path = entry.path();
             let metadata = fs::metadata(path)?;
             let modified = metadata.modified()?;
@@ -79,7 +98,18 @@ impl Manifest {
                 .strip_prefix(root)
                 .map_err(|error| MinSyncError::Manifest(error.to_string()))?;
             let manifest_path = relative_path.to_string_lossy().replace('\\', "/");
-            let content_hash = hash_file(path)?;
+            let fingerprint = metadata_fingerprint(&metadata, mtime_ns);
+            let content_hash = match baseline
+                .and_then(|manifest| manifest.files.get(&manifest_path))
+                .filter(|entry| fingerprint.is_some() && entry.fingerprint == fingerprint)
+            {
+                Some(entry) => entry.content_hash.clone(),
+                None => {
+                    stats.files_rehashed += 1;
+                    stats.bytes_hashed += metadata.len();
+                    hash_file(path)?
+                }
+            };
 
             manifest.files.insert(
                 manifest_path,
@@ -87,11 +117,12 @@ impl Manifest {
                     size: metadata.len(),
                     mtime_ns,
                     content_hash,
+                    fingerprint,
                 },
             );
         }
 
-        Ok(manifest)
+        Ok((manifest, stats))
     }
 
     pub fn diff(old: &Manifest, new: &Manifest) -> Vec<FileChange> {
@@ -184,6 +215,26 @@ fn hash_file(path: &Path) -> Result<String> {
     Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 
+#[cfg(unix)]
+fn metadata_fingerprint(metadata: &fs::Metadata, mtime_ns: u128) -> Option<String> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(format!(
+        "{}:{}:{}:{}:{}:{}",
+        metadata.len(),
+        mtime_ns,
+        metadata.ctime(),
+        metadata.ctime_nsec(),
+        metadata.dev(),
+        metadata.ino(),
+    ))
+}
+
+#[cfg(not(unix))]
+fn metadata_fingerprint(_metadata: &fs::Metadata, _mtime_ns: u128) -> Option<String> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -194,6 +245,7 @@ mod tests {
             size: 1,
             mtime_ns: 1,
             content_hash: hash.to_string(),
+            fingerprint: None,
         }
     }
 
@@ -253,6 +305,11 @@ mod tests {
             .get_mut("a.txt")
             .expect("baseline entry")
             .content_hash = "sha256:baseline".to_string();
+        baseline
+            .files
+            .get_mut("a.txt")
+            .expect("baseline entry")
+            .fingerprint = None;
 
         let manifest = Manifest::scan_with_baseline(dir.path(), "source-1", Some(&baseline))
             .expect("scan with baseline");
@@ -290,23 +347,20 @@ mod tests {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("a.txt");
         fs::write(&path, "alpha").expect("write original file");
+        let mut baseline = Manifest::scan(dir.path(), "source-1").expect("scan baseline");
         fs::write(&path, "bravo").expect("write same-size replacement");
-        let metadata = fs::metadata(&path).expect("read replacement metadata");
-        let mtime_ns = metadata
+        let replacement_mtime_ns = fs::metadata(&path)
+            .expect("read replacement metadata")
             .modified()
             .expect("read replacement mtime")
             .duration_since(UNIX_EPOCH)
             .expect("replacement mtime after epoch")
             .as_nanos();
-        let mut baseline = Manifest::new("source-1");
-        baseline.files.insert(
-            "a.txt".to_string(),
-            ManifestFileEntry {
-                size: metadata.len(),
-                mtime_ns,
-                content_hash: prefixed_sha256(b"alpha"),
-            },
-        );
+        baseline
+            .files
+            .get_mut("a.txt")
+            .expect("baseline entry")
+            .mtime_ns = replacement_mtime_ns;
 
         let manifest = Manifest::scan_with_baseline(dir.path(), "source-1", Some(&baseline))
             .expect("scan with baseline");
@@ -315,6 +369,65 @@ mod tests {
             manifest.files["a.txt"].content_hash,
             prefixed_sha256(b"bravo")
         );
+    }
+
+    #[test]
+    fn test_scan_with_baseline_reuses_matching_fingerprint_without_hashing() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        fs::write(dir.path().join("a.txt"), "alpha").expect("write file");
+        let baseline = Manifest::scan(dir.path(), "source-1").expect("scan baseline");
+
+        let (manifest, stats) =
+            Manifest::scan_with_baseline_stats(dir.path(), "source-1", Some(&baseline))
+                .expect("scan with baseline");
+
+        assert_eq!(
+            manifest.files["a.txt"].content_hash,
+            baseline.files["a.txt"].content_hash
+        );
+        assert_eq!(stats.files_rehashed, 0);
+        assert_eq!(stats.bytes_hashed, 0);
+        assert_eq!(stats.files_examined, 1);
+    }
+
+    #[test]
+    fn test_scan_with_baseline_rehashes_same_size_replacement() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("a.txt");
+        fs::write(&path, "alpha").expect("write original file");
+        let baseline = Manifest::scan(dir.path(), "source-1").expect("scan baseline");
+        let original_mtime = fs::metadata(&path)
+            .expect("read original metadata")
+            .modified()
+            .expect("read original mtime");
+        fs::write(&path, "bravo").expect("write replacement");
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(original_mtime))
+            .expect("restore original mtime");
+
+        let (manifest, stats) =
+            Manifest::scan_with_baseline_stats(dir.path(), "source-1", Some(&baseline))
+                .expect("scan replacement");
+
+        assert_eq!(
+            manifest.files["a.txt"].content_hash,
+            prefixed_sha256(b"bravo")
+        );
+        assert_eq!(stats.files_rehashed, 1);
+        assert_eq!(stats.bytes_hashed, 5);
+    }
+
+    #[test]
+    fn test_scan_without_baseline_rehashes_every_file() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        fs::write(dir.path().join("a.txt"), "alpha").expect("write a");
+        fs::write(dir.path().join("b.txt"), "bravo").expect("write b");
+
+        let (_manifest, stats) =
+            Manifest::scan_with_baseline_stats(dir.path(), "source-1", None).expect("full scan");
+
+        assert_eq!(stats.files_examined, 2);
+        assert_eq!(stats.files_rehashed, 2);
+        assert_eq!(stats.bytes_hashed, 10);
     }
 
     #[test]

--- a/src/verify/sampling.rs
+++ b/src/verify/sampling.rs
@@ -55,6 +55,7 @@ mod tests {
                     size: 0,
                     mtime_ns: 0,
                     content_hash: "hash".to_string(),
+                    fingerprint: None,
                 },
             );
         }

--- a/tests/issue_46_freshness_benchmark.rs
+++ b/tests/issue_46_freshness_benchmark.rs
@@ -1,0 +1,76 @@
+use minsync::manifest::Manifest;
+use std::time::{Duration, Instant};
+
+const CORPUS_SIZES: [usize; 4] = [64, 256, 512, 1024];
+const FILE_BYTES: usize = 16 * 1024;
+const SAMPLES: usize = 15;
+
+#[derive(Debug)]
+struct Measurement {
+    p50: Duration,
+    p95: Duration,
+    files_examined: usize,
+    files_rehashed: usize,
+    bytes_hashed: u64,
+}
+
+fn percentile(samples: &mut [Duration], percentile: usize) -> Duration {
+    samples.sort_unstable();
+    let index = (samples.len() - 1) * percentile / 100;
+    samples[index]
+}
+
+fn measure(root: &std::path::Path, baseline: Option<&Manifest>) -> Measurement {
+    let mut durations = Vec::with_capacity(SAMPLES);
+    let mut final_stats = None;
+
+    for _ in 0..SAMPLES {
+        let started = Instant::now();
+        let (_manifest, stats) = Manifest::scan_with_baseline_stats(root, "benchmark", baseline)
+            .expect("benchmark scan succeeds");
+        durations.push(started.elapsed());
+        final_stats = Some(stats);
+    }
+
+    let stats = final_stats.expect("at least one sample");
+    let mut p50_samples = durations.clone();
+    Measurement {
+        p50: percentile(&mut p50_samples, 50),
+        p95: percentile(&mut durations, 95),
+        files_examined: stats.files_examined,
+        files_rehashed: stats.files_rehashed,
+        bytes_hashed: stats.bytes_hashed,
+    }
+}
+
+#[test]
+#[ignore = "deterministic performance measurement; run with --ignored --nocapture"]
+fn benchmark_issue_46_unchanged_freshness() {
+    println!(
+        "corpus_files,file_bytes,mode,p50_us,p95_us,files_examined,files_rehashed,bytes_hashed"
+    );
+
+    for file_count in CORPUS_SIZES {
+        let dir = tempfile::tempdir().expect("create benchmark tempdir");
+        let content = vec![b'x'; FILE_BYTES];
+        for index in 0..file_count {
+            std::fs::write(dir.path().join(format!("file-{index:04}.txt")), &content)
+                .expect("write benchmark file");
+        }
+
+        let baseline = Manifest::scan(dir.path(), "benchmark").expect("create baseline");
+        let current = measure(dir.path(), None);
+        let optimized = measure(dir.path(), Some(&baseline));
+
+        for (mode, measurement) in [("current_full_hash", current), ("optimized", optimized)] {
+            println!(
+                "{file_count},{FILE_BYTES},{mode},{},{},{},{},{}",
+                measurement.p50.as_micros(),
+                measurement.p95.as_micros(),
+                measurement.files_examined,
+                measurement.files_rehashed,
+                measurement.bytes_hashed
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Reuse the persisted manifest content hash when a conservative Unix metadata fingerprint is unchanged.
- Fingerprint includes size, mtime, ctime, device, and inode; same-size/restored-mtime replacements change ctime and are rehashed.
- Legacy manifests and unsupported platforms conservatively rehash; `--full` remains authoritative and always hashes.
- MinSync remains the sole freshness owner; no AutoRAG fingerprint or query/index behavior changed.

## Issue

Closes #46

## RED -> GREEN evidence

- Mutation RED: forced the reuse predicate false and ran `cargo test --lib manifest::tests::test_scan_with_baseline_reuses_matching_fingerprint_without_hashing -- --nocapture`; assertion failed with `left: 1`, `right: 0` for `files_rehashed`.
- GREEN: restored the implementation; the targeted test passed 1/1.
- Final manifest tests: 19/19 passed (`/tmp/ulw-46/final-manifest-tests.txt`).
- Final sync tests: 13/13 passed (`/tmp/ulw-46/final-sync-tests.txt`).

## Performance evidence

Deterministic benchmark command:

```bash
cargo test --test issue_46_freshness_benchmark -- --ignored --nocapture
```

Corpus files are 16 KiB each; 15 samples per case; p50/p95 are reported in microseconds.

| Files | Full-hash p50/p95 | Optimized p50/p95 | Speedup p50 | Optimized files rehashed | Optimized bytes hashed |
|---:|---:|---:|---:|---:|---:|
| 64 | 37,072 / 37,980 us | 349 / 385 us | 106.2x | 0 | 0 |
| 256 | 148,129 / 149,012 us | 1,118 / 1,239 us | 132.5x | 0 | 0 |
| 512 | 295,558 / 297,816 us | 2,236 / 2,507 us | 132.2x | 0 | 0 |
| 1024 | 596,363 / 605,860 us | 4,131 / 4,283 us | 144.3x | 0 | 0 |

Full output: `/tmp/ulw-46/final-benchmark.txt`.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo build --release`: passed.
- Release CLI QA: `sync --help` exit 0; uninitialized sync exit 1 with an actionable I/O error; initialized empty workspace first sync reports `initial_sync=true`; second sync reports `already_up_to_date=true` with zero files processed. Full output: `/tmp/ulw-46/release-cli-qa.txt`.
- `cargo test --all-targets`: 202 tests passed. One unrelated pre-existing failure remains in `bm25_cli_e2e::bm25_cli_queries_live_lancedb_without_embedder_credentials` (the working tree change does not touch query/embedder code).

## Safety trade-off

The fast path trusts a persisted metadata fingerprint only when the platform exposes the Unix metadata used above. A writer that mutates content after metadata is observed remains subject to the normal concurrent-write race; use `minsync sync --full` for an authoritative rescan. Metadata changes such as permissions update ctime and trigger a rehash. Renames/adds/deletes remain path-level manifest changes.
