### PR TITLE
fix: guard Windows watch flag in release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,19 @@ jobs:
 
       - run: cargo build --release --target ${{ matrix.target }}
 
+      - name: Smoke test Windows watch flags
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $exe = "target/${{ matrix.target }}/release/minsync.exe"
+          $output = & $exe watch --watch-on-sync-error --help 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows watch flag was rejected: $output"
+          }
+          if ($output -notmatch "--watch-on-sync-error") {
+            throw "Windows watch help omitted --watch-on-sync-error: $output"
+          }
+
       - name: Package (unix)
         if: matrix.archive == 'tar.gz'
         run: |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,3 +93,23 @@ pub enum Commands {
         watch_on_sync_error: bool,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Commands};
+    use clap::Parser;
+
+    #[test]
+    fn watch_accepts_sync_error_recovery_flag() {
+        let cli = Cli::try_parse_from(["minsync", "watch", "--watch-on-sync-error"])
+            .expect("watch recovery flag is accepted");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Watch {
+                watch_on_sync_error: true,
+                ..
+            }
+        ));
+    }
+}

--- a/tests/ci_contract.rs
+++ b/tests/ci_contract.rs
@@ -48,6 +48,23 @@ fn ci_workflow_defines_required_multi_os_validation() {
 }
 
 #[test]
+fn release_workflow_smoke_tests_windows_watch_flag() {
+    let workflow = read_file(".github/workflows/release.yml");
+
+    for needle in [
+        "matrix.target == 'x86_64-pc-windows-msvc'",
+        "target/${{ matrix.target }}/release/minsync.exe",
+        "watch --watch-on-sync-error --help",
+        "--watch-on-sync-error",
+    ] {
+        assert!(
+            workflow.contains(needle),
+            "expected Windows release smoke test to contain {needle:?}"
+        );
+    }
+}
+
+#[test]
 fn readme_documents_supported_ci_assumptions() {
     let readme = read_file("README.md");
 


### PR DESCRIPTION
Related to #44

This PR does **not** close #44. The published GitHub Latest zip is still v0.3.0 (2026-07-28), which predates `--watch-on-sync-error` (added in 52d7695 on 2026-08-26). Shipping a 0.4.x GitHub release is what actually fixes the user-facing symptom.

## Summary
- add a CLI parser regression test for `watch --watch-on-sync-error`
- add a Windows-only release smoke test before packaging
- require the packaged Windows binary to accept the documented flag

## Verification
- RED: temporary flag mutation produced clap `UnknownArgument` for `--watch-on-sync-error`
- GREEN: `watch_accepts_sync_error_recovery_flag` passed
- Windows SSH: 0.4.2 release binary reached `Watching ... for changes...`
- Windows malformed input: `--debounce-ms nope` returned exit 2 with clap validation error
- `cargo fmt --all -- --check` passed
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- 200 library tests passed
- 9 CI contract tests passed

Note: the pre-existing BM25 CLI E2E assertion still fails because it observes an embedding request; unrelated code was not changed.