### PR TITLE
fix: reset vector store on forced init

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -93,24 +93,24 @@ async fn sync(
     wait: bool,
     batch_size: Option<usize>,
 ) -> Result<()> {
+    let ms = MinSync::new(root.clone());
+    let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), wait)?;
     let mut config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     if let Some(bs) = batch_size {
         config.embedder.batch_size = bs;
     }
     let chunker = crate::chunker::create_chunker(&config)?;
     let embedder = crate::embedder::create_embedder(&config)?;
-    let store_path = minsync_dir.join(&config.collection.path);
+    let store_path = crate::sync::collection_store_path(minsync_dir, &config.collection.path)?;
     let mut store = crate::vectorstore::create_vectorstore(&config, &store_path)?;
 
-    let ms = MinSync::new(root);
     let result = ms
-        .sync(
+        .sync_locked(
             chunker.as_ref(),
             embedder.as_ref(),
             store.as_mut(),
             full,
             dry_run,
-            wait,
         )
         .await?;
 
@@ -157,8 +157,9 @@ async fn query(
     k: usize,
     mode: QueryMode,
 ) -> Result<()> {
+    let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
-    let store_path = minsync_dir.join(&config.collection.path);
+    let store_path = crate::sync::collection_store_path(minsync_dir, &config.collection.path)?;
     let store = crate::vectorstore::create_vectorstore(&config, &store_path)?;
     let results = match mode {
         QueryMode::Bm25 => crate::query::query_text(minsync_dir, text, k, store.as_ref(), None)?,
@@ -229,9 +230,10 @@ async fn status(format: &OutputFormat, minsync_dir: &std::path::Path) -> Result<
 }
 
 async fn check(format: &OutputFormat, minsync_dir: &std::path::Path) -> Result<()> {
+    let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     let embedder = crate::embedder::create_embedder(&config)?;
-    let store_path = minsync_dir.join(&config.collection.path);
+    let store_path = crate::sync::collection_store_path(minsync_dir, &config.collection.path)?;
     let store = crate::vectorstore::create_vectorstore(&config, &store_path)?;
 
     let result = crate::verify::check(minsync_dir, embedder.as_ref(), store.as_ref()).await?;
@@ -269,9 +271,10 @@ async fn verify(
     all: bool,
     sample: usize,
 ) -> Result<()> {
+    let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     let chunker = crate::chunker::create_chunker(&config)?;
-    let store_path = minsync_dir.join(&config.collection.path);
+    let store_path = crate::sync::collection_store_path(minsync_dir, &config.collection.path)?;
     let mut store = crate::vectorstore::create_vectorstore(&config, &store_path)?;
     let sample_count = if all { None } else { Some(sample) };
 
@@ -309,6 +312,7 @@ async fn watch(
     debounce_ms: Option<u64>,
     watch_on_sync_error: bool,
 ) -> Result<()> {
+    let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     let chunker = crate::chunker::create_chunker(&config)?;
     let embedder: Box<dyn crate::embedder::Embedder> = if watch_on_sync_error {
@@ -316,14 +320,14 @@ async fn watch(
     } else {
         crate::embedder::create_embedder(&config)?
     };
-    let store_path = minsync_dir.join(&config.collection.path);
+    let store_path = crate::sync::collection_store_path(minsync_dir, &config.collection.path)?;
     let mut store = crate::vectorstore::create_vectorstore(&config, &store_path)?;
 
     if let OutputFormat::Text = format {
         println!("Watching {} for changes...", root.display());
     }
 
-    crate::watch::run(
+    crate::watch::run_locked(
         root,
         chunker.as_ref(),
         embedder.as_ref(),

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -41,9 +41,11 @@ impl MinSync {
         let _lock = force
             .then(|| FileLock::acquire(&self.minsync_dir.join("lock"), false))
             .transpose()?;
-        if force {
-            self.reset_forced_state()?;
-        }
+        let reset_staging = if force {
+            Some(self.reset_forced_state()?)
+        } else {
+            None
+        };
         std::fs::create_dir_all(&self.minsync_dir)?;
         let source_id = uuid::Uuid::new_v4().to_string();
         let mut config = Config::default_for(&source_id);
@@ -52,28 +54,39 @@ impl MinSync {
 
         config.save(&self.minsync_dir.join("config.toml"))?;
         Manifest::scan(&self.root, &source_id)?.save(&self.minsync_dir.join("manifest.json"))?;
+        if let Some(staging) = reset_staging {
+            std::fs::remove_dir_all(staging)?;
+        }
 
         Ok(config)
     }
 
-    fn reset_forced_state(&self) -> Result<()> {
+    fn reset_forced_state(&self) -> Result<PathBuf> {
         let config_path = self.minsync_dir.join("config.toml");
-        if config_path.exists() {
-            let previous = Config::load(&config_path)?;
+        let previous = if config_path.exists() {
+            Some(Config::load(&config_path)?)
+        } else {
+            None
+        };
+        let staging = self
+            .minsync_dir
+            .join(format!(".reset-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir(&staging)?;
+
+        if let Some(previous) = previous {
             let previous_store =
                 collection_store_path(&self.minsync_dir, &previous.collection.path)?;
+            for state_file in ["cursor.json", "txn.json"] {
+                let path = self.minsync_dir.join(state_file);
+                if path.exists() {
+                    std::fs::rename(&path, staging.join(state_file))?;
+                }
+            }
             if previous_store.exists() {
-                std::fs::remove_dir_all(previous_store)?;
+                std::fs::rename(previous_store, staging.join("store"))?;
             }
         }
-
-        for state_file in ["cursor.json", "txn.json"] {
-            let path = self.minsync_dir.join(state_file);
-            if path.exists() {
-                std::fs::remove_file(path)?;
-            }
-        }
-        Ok(())
+        Ok(staging)
     }
 }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -15,7 +15,7 @@ use crate::types::SyncResult;
 use crate::vectorstore::{Filter, VectorStore};
 use indexer::{index_file, SyncFileContext};
 use result::{change_path, empty_sync_result};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 pub struct MinSync {
     root: PathBuf,
@@ -38,6 +38,9 @@ impl MinSync {
             return Err(MinSyncError::AlreadyInitialized);
         }
 
+        if force {
+            self.reset_forced_state()?;
+        }
         std::fs::create_dir_all(&self.minsync_dir)?;
         let source_id = uuid::Uuid::new_v4().to_string();
         let mut config = Config::default_for(&source_id);
@@ -48,6 +51,47 @@ impl MinSync {
         Manifest::scan(&self.root, &source_id)?.save(&self.minsync_dir.join("manifest.json"))?;
 
         Ok(config)
+    }
+
+    fn reset_forced_state(&self) -> Result<()> {
+        let config_path = self.minsync_dir.join("config.toml");
+        if config_path.exists() {
+            let previous = Config::load(&config_path)?;
+            let previous_store = self.collection_store_path(&previous.collection.path)?;
+            if previous_store.exists() {
+                std::fs::remove_dir_all(previous_store)?;
+            }
+        }
+
+        for state_file in ["cursor.json", "txn.json"] {
+            let path = self.minsync_dir.join(state_file);
+            if path.exists() {
+                std::fs::remove_file(path)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn collection_store_path(&self, configured_path: &str) -> Result<PathBuf> {
+        let path = Path::new(configured_path);
+        let mut has_normal_component = false;
+        for component in path.components() {
+            match component {
+                Component::Normal(_) => has_normal_component = true,
+                Component::CurDir => {}
+                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                    return Err(MinSyncError::Config(format!(
+                        "collection.path must stay inside .minsync/: {configured_path}"
+                    )));
+                }
+            }
+        }
+        if !has_normal_component {
+            return Err(MinSyncError::Config(
+                "collection.path must name a directory inside .minsync/".to_string(),
+            ));
+        }
+        Ok(self.minsync_dir.join(path))
     }
 
     /// Incrementally synchronize changed files into the supplied vector store.
@@ -308,6 +352,80 @@ mod tests {
             .expect("force init succeeds");
 
         assert_ne!(first.source_id, second.source_id);
+    }
+
+    #[test]
+    fn test_init_force_removes_previous_store_and_cursor() {
+        let (dir, sync, _chunker, _embedder, _store) = fixture();
+        sync.init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("first init succeeds");
+        std::fs::create_dir_all(sync.minsync_dir.join("store"))
+            .expect("create previous vector store");
+        std::fs::write(sync.minsync_dir.join("store/data"), "stale")
+            .expect("write previous vector store data");
+        std::fs::write(sync.minsync_dir.join("cursor.json"), "{}").expect("write stale cursor");
+        std::fs::write(sync.minsync_dir.join("txn.json"), "{}").expect("write stale transaction");
+
+        sync.init(true, "openai:text-embedding-3-small", "recursive")
+            .expect("force init succeeds");
+
+        assert!(!dir.path().join(".minsync/store").exists());
+        assert!(!dir.path().join(".minsync/cursor.json").exists());
+        assert!(!dir.path().join(".minsync/txn.json").exists());
+    }
+
+    #[test]
+    fn test_init_force_allows_lancedb_dimension_change() {
+        let (_dir, sync, _chunker, _embedder, _store) = fixture();
+        let mut first = sync
+            .init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("first init succeeds");
+        first.vectorstore.options["dimension"] = toml::Value::Integer(4);
+        first
+            .save(&sync.minsync_dir.join("config.toml"))
+            .expect("save first dimension");
+        let store_path = sync.minsync_dir.join(&first.collection.path);
+        let store = crate::vectorstore::lancedb_store::LanceDbStore::open_or_create(&store_path, 4)
+            .expect("create first-dimension store");
+        drop(store);
+
+        let mut second = sync
+            .init(true, "openai:text-embedding-3-small", "recursive")
+            .expect("force init succeeds");
+        second.vectorstore.options["dimension"] = toml::Value::Integer(8);
+        second
+            .save(&sync.minsync_dir.join("config.toml"))
+            .expect("save second dimension");
+        let reopened = crate::vectorstore::lancedb_store::LanceDbStore::open_or_create(
+            &sync.minsync_dir.join(&second.collection.path),
+            8,
+        )
+        .expect("open second-dimension store");
+
+        assert_eq!(reopened.dimension(), 8);
+        assert_eq!(reopened.doc_count(), 0);
+    }
+
+    #[test]
+    fn test_init_force_rejects_collection_path_outside_minsync() {
+        let (dir, sync, _chunker, _embedder, _store) = fixture();
+        let mut first = sync
+            .init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("first init succeeds");
+        first.collection.path = "../outside".to_string();
+        first
+            .save(&sync.minsync_dir.join("config.toml"))
+            .expect("save unsafe collection path");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&outside).expect("create outside directory");
+        std::fs::write(outside.join("data"), "keep").expect("write outside data");
+
+        let error = sync
+            .init(true, "openai:text-embedding-3-small", "recursive")
+            .expect_err("unsafe collection path must fail");
+
+        assert!(error.to_string().contains("must stay inside .minsync"));
+        assert!(outside.join("data").exists());
     }
 
     #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -38,6 +38,9 @@ impl MinSync {
             return Err(MinSyncError::AlreadyInitialized);
         }
 
+        let _lock = force
+            .then(|| FileLock::acquire(&self.minsync_dir.join("lock"), false))
+            .transpose()?;
         if force {
             self.reset_forced_state()?;
         }
@@ -57,7 +60,8 @@ impl MinSync {
         let config_path = self.minsync_dir.join("config.toml");
         if config_path.exists() {
             let previous = Config::load(&config_path)?;
-            let previous_store = self.collection_store_path(&previous.collection.path)?;
+            let previous_store =
+                collection_store_path(&self.minsync_dir, &previous.collection.path)?;
             if previous_store.exists() {
                 std::fs::remove_dir_all(previous_store)?;
             }
@@ -71,29 +75,55 @@ impl MinSync {
         }
         Ok(())
     }
+}
 
-    fn collection_store_path(&self, configured_path: &str) -> Result<PathBuf> {
-        let path = Path::new(configured_path);
-        let mut has_normal_component = false;
-        for component in path.components() {
-            match component {
-                Component::Normal(_) => has_normal_component = true,
-                Component::CurDir => {}
-                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+pub(crate) fn collection_store_path(minsync_dir: &Path, configured_path: &str) -> Result<PathBuf> {
+    let base = minsync_dir.canonicalize()?;
+    let path = Path::new(configured_path);
+    let mut candidate = base.clone();
+    let mut has_normal_component = false;
+    for component in path.components() {
+        match component {
+            Component::Normal(name) => {
+                has_normal_component = true;
+                candidate.push(name);
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(MinSyncError::Config(format!(
+                    "collection.path must stay inside .minsync/: {configured_path}"
+                )));
+            }
+        }
+
+        match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() {
+                    return Err(MinSyncError::Config(format!(
+                        "collection.path must stay inside .minsync/: {configured_path}"
+                    )));
+                }
+                let resolved = candidate.canonicalize()?;
+                if !resolved.starts_with(&base) {
                     return Err(MinSyncError::Config(format!(
                         "collection.path must stay inside .minsync/: {configured_path}"
                     )));
                 }
             }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => return Err(error.into()),
         }
-        if !has_normal_component {
-            return Err(MinSyncError::Config(
-                "collection.path must name a directory inside .minsync/".to_string(),
-            ));
-        }
-        Ok(self.minsync_dir.join(path))
     }
 
+    if !has_normal_component {
+        return Err(MinSyncError::Config(
+            "collection.path must name a directory inside .minsync/".to_string(),
+        ));
+    }
+    Ok(base.join(path))
+}
+
+impl MinSync {
     /// Incrementally synchronize changed files into the supplied vector store.
     pub async fn sync(
         &self,
@@ -104,13 +134,25 @@ impl MinSync {
         dry_run: bool,
         wait_lock: bool,
     ) -> Result<SyncResult> {
+        let _lock = FileLock::acquire(&self.minsync_dir.join("lock"), wait_lock)?;
+        self.sync_locked(chunker, embedder, store, full, dry_run)
+            .await
+    }
+
+    pub(crate) async fn sync_locked(
+        &self,
+        chunker: &dyn Chunker,
+        embedder: &dyn Embedder,
+        store: &mut dyn VectorStore,
+        full: bool,
+        dry_run: bool,
+    ) -> Result<SyncResult> {
         let config_path = self.minsync_dir.join("config.toml");
         if !config_path.exists() {
             return Err(MinSyncError::NotInitialized);
         }
 
         let config = Config::load(&config_path)?;
-        let _lock = FileLock::acquire(&self.minsync_dir.join("lock"), wait_lock)?;
 
         let txn_path = self.minsync_dir.join("txn.json");
         let cursor_path = self.minsync_dir.join("cursor.json");
@@ -426,6 +468,48 @@ mod tests {
 
         assert!(error.to_string().contains("must stay inside .minsync"));
         assert!(outside.join("data").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_init_force_rejects_intermediate_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, sync, _chunker, _embedder, _store) = fixture();
+        let mut first = sync
+            .init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("first init succeeds");
+        first.collection.path = "escape/store".to_string();
+        first
+            .save(&sync.minsync_dir.join("config.toml"))
+            .expect("save symlink path");
+
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(outside.join("store")).expect("create outside store");
+        std::fs::write(outside.join("store/data"), "keep").expect("write outside data");
+        symlink(&outside, sync.minsync_dir.join("escape")).expect("create escape symlink");
+
+        let error = sync
+            .init(true, "openai:text-embedding-3-small", "recursive")
+            .expect_err("symlink collection path must fail");
+
+        assert!(error.to_string().contains("must stay inside .minsync"));
+        assert!(outside.join("store/data").exists());
+    }
+
+    #[test]
+    fn test_init_force_respects_workspace_lock() {
+        let (_dir, sync, _chunker, _embedder, _store) = fixture();
+        sync.init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("first init succeeds");
+        let _lock =
+            FileLock::acquire(&sync.minsync_dir.join("lock"), false).expect("hold workspace lock");
+
+        let error = sync
+            .init(true, "openai:text-embedding-3-small", "recursive")
+            .expect_err("force init must reject a locked workspace");
+
+        assert!(matches!(error, MinSyncError::LockFailed));
     }
 
     #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -38,6 +38,9 @@ impl MinSync {
             return Err(MinSyncError::AlreadyInitialized);
         }
 
+        if force {
+            std::fs::create_dir_all(&self.minsync_dir)?;
+        }
         let _lock = force
             .then(|| FileLock::acquire(&self.minsync_dir.join("lock"), false))
             .transpose()?;
@@ -123,7 +126,7 @@ pub(crate) fn collection_store_path(minsync_dir: &Path, configured_path: &str) -
                     )));
                 }
             }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => return Err(error.into()),
         }
     }
@@ -523,6 +526,34 @@ mod tests {
             .expect_err("force init must reject a locked workspace");
 
         assert!(matches!(error, MinSyncError::LockFailed));
+    }
+
+    #[test]
+    fn test_init_force_creates_missing_workspace_before_locking() {
+        let (_dir, sync, _chunker, _embedder, _store) = fixture();
+
+        sync.init(true, "openai:text-embedding-3-small", "recursive")
+            .expect("force init succeeds in a new workspace");
+    }
+
+    #[test]
+    fn test_init_force_rejects_parent_escape_after_missing_component() {
+        let (dir, sync, _chunker, _embedder, _store) = fixture();
+        sync.init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("first init succeeds");
+        let mut config =
+            Config::load(&sync.minsync_dir.join("config.toml")).expect("load initial config");
+        config.collection.path = "missing/../../outside".to_string();
+        config
+            .save(&sync.minsync_dir.join("config.toml"))
+            .expect("save unsafe collection path");
+
+        let error = sync
+            .init(true, "openai:text-embedding-3-small", "recursive")
+            .expect_err("parent escape after missing component must fail");
+
+        assert!(error.to_string().contains("must stay inside .minsync"));
+        assert!(!dir.path().join("outside").exists());
     }
 
     #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -76,18 +76,18 @@ impl MinSync {
             .join(format!(".reset-{}", uuid::Uuid::new_v4().simple()));
         std::fs::create_dir(&staging)?;
 
-        if let Some(previous) = previous {
-            let previous_store =
-                collection_store_path(&self.minsync_dir, &previous.collection.path)?;
-            for state_file in ["cursor.json", "txn.json"] {
-                let path = self.minsync_dir.join(state_file);
-                if path.exists() {
-                    std::fs::rename(&path, staging.join(state_file))?;
-                }
+        for state_file in ["cursor.json", "txn.json"] {
+            let path = self.minsync_dir.join(state_file);
+            if path.exists() {
+                std::fs::rename(&path, staging.join(state_file))?;
             }
-            if previous_store.exists() {
-                std::fs::rename(previous_store, staging.join("store"))?;
-            }
+        }
+        let previous_store_path = previous
+            .map(|config| config.collection.path)
+            .unwrap_or_else(|| "store".to_string());
+        let previous_store = collection_store_path(&self.minsync_dir, &previous_store_path)?;
+        if previous_store.exists() {
+            std::fs::rename(previous_store, staging.join("store"))?;
         }
         Ok(staging)
     }
@@ -554,6 +554,23 @@ mod tests {
 
         assert!(error.to_string().contains("must stay inside .minsync"));
         assert!(!dir.path().join("outside").exists());
+    }
+
+    #[test]
+    fn test_init_force_resets_partial_workspace_without_config() {
+        let (_dir, sync, _chunker, _embedder, _store) = fixture();
+        std::fs::create_dir_all(sync.minsync_dir.join("store")).expect("create stale vector store");
+        std::fs::write(sync.minsync_dir.join("store/data"), "stale")
+            .expect("write stale vector store data");
+        std::fs::write(sync.minsync_dir.join("cursor.json"), "{}").expect("write stale cursor");
+        std::fs::write(sync.minsync_dir.join("txn.json"), "{}").expect("write stale transaction");
+
+        sync.init(true, "openai:text-embedding-3-small", "recursive")
+            .expect("force init succeeds");
+
+        assert!(!sync.minsync_dir.join("store").exists());
+        assert!(!sync.minsync_dir.join("cursor.json").exists());
+        assert!(!sync.minsync_dir.join("txn.json").exists());
     }
 
     #[test]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -92,6 +92,7 @@ pub async fn run(
     debounce_ms: Option<u64>,
     startup: WatchStartup,
 ) -> Result<()> {
+    let _lock = crate::state::FileLock::acquire(&root.join(".minsync/lock"), false)?;
     let runtime = WatchRuntime {
         startup,
         progress: None,
@@ -100,7 +101,26 @@ pub async fn run(
             let _ = tokio::signal::ctrl_c().await;
         }),
     };
-    run_inner(root, chunker, embedder, store, debounce_ms, runtime).await
+    run_inner(root, chunker, embedder, store, debounce_ms, runtime, true).await
+}
+
+pub(crate) async fn run_locked(
+    root: PathBuf,
+    chunker: &dyn Chunker,
+    embedder: &dyn Embedder,
+    store: &mut dyn VectorStore,
+    debounce_ms: Option<u64>,
+    startup: WatchStartup,
+) -> Result<()> {
+    let runtime = WatchRuntime {
+        startup,
+        progress: None,
+        startup_status: None,
+        shutdown: Box::pin(async {
+            let _ = tokio::signal::ctrl_c().await;
+        }),
+    };
+    run_inner(root, chunker, embedder, store, debounce_ms, runtime, true).await
 }
 
 pub async fn run_with_shutdown(
@@ -111,6 +131,7 @@ pub async fn run_with_shutdown(
     debounce_ms: Option<u64>,
     control: WatchControl,
 ) -> Result<()> {
+    let _lock = crate::state::FileLock::acquire(&root.join(".minsync/lock"), false)?;
     let runtime = WatchRuntime {
         startup: control.startup,
         progress: control.progress,
@@ -119,7 +140,7 @@ pub async fn run_with_shutdown(
             let _ = control.shutdown.await;
         }),
     };
-    run_inner(root, chunker, embedder, store, debounce_ms, runtime).await
+    run_inner(root, chunker, embedder, store, debounce_ms, runtime, true).await
 }
 
 async fn run_inner(
@@ -129,6 +150,7 @@ async fn run_inner(
     store: &mut dyn VectorStore,
     debounce_ms: Option<u64>,
     mut runtime: WatchRuntime,
+    lock_held: bool,
 ) -> Result<()> {
     let minsync_dir = root.join(".minsync");
     let debounce = Duration::from_millis(debounce_ms.unwrap_or(500));
@@ -148,7 +170,7 @@ async fn run_inner(
 
     let sync = MinSync::new(root.clone());
 
-    let initial = run_sync(&sync, chunker, embedder, store).await;
+    let initial = run_sync(&sync, chunker, embedder, store, lock_held).await;
     if let Ok(result) = initial.as_ref() {
         if let Some(status) = &runtime.startup_status {
             let _ = status.send(WatchStartupStatus::InitialSyncSucceeded);
@@ -192,7 +214,7 @@ async fn run_inner(
                             if needs_rescan {
                                 tracing::info!("rescan requested, running incremental sync");
                             }
-                            match run_sync(&sync, chunker, embedder, store).await {
+                            match run_sync(&sync, chunker, embedder, store, lock_held).await {
                                 Ok(result) => {
                                     if let Some(progress) = &runtime.progress {
                                         let _ = progress.send(result);
@@ -222,10 +244,15 @@ async fn run_sync(
     chunker: &dyn Chunker,
     embedder: &dyn Embedder,
     store: &mut dyn VectorStore,
+    lock_held: bool,
 ) -> Result<crate::types::SyncResult> {
-    let result = sync
-        .sync(chunker, embedder, store, false, false, false)
-        .await?;
+    let result = if lock_held {
+        sync.sync_locked(chunker, embedder, store, false, false)
+            .await?
+    } else {
+        sync.sync(chunker, embedder, store, false, false, false)
+            .await?
+    };
     {
         if result.already_up_to_date {
             tracing::info!("watch sync: already up to date");


### PR DESCRIPTION
## Summary
- reset the previous configured LanceDB collection during `minsync init --force`
- remove stale cursor and transaction state so the next sync is a clean initial sync
- reject unsafe collection paths outside `.minsync/`
- add regression coverage for forced reinitialization and vector dimension changes

Closes #40

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- isolated CLI forced-init smoke test
