### PR TITLE
fix(embedder): handle model context overflow

### DIFF
--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -89,6 +89,10 @@ pub struct EmbedderConfig {
     pub query_prefix: Option<String>,
     #[serde(default)]
     pub passage_prefix: Option<String>,
+    /// Ask TEI-compatible servers to truncate inputs at the model context.
+    /// Keep disabled by default so oversized content is surfaced explicitly.
+    #[serde(default)]
+    pub truncate: bool,
 }
 
 fn default_batch_size() -> usize {
@@ -177,6 +181,7 @@ impl Config {
                 base_url: None,
                 query_prefix: None,
                 passage_prefix: None,
+                truncate: false,
             },
             vectorstore: VectorStoreConfig {
                 id: "lancedb".to_string(),

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -80,7 +80,8 @@ pub fn create_embedder(config: &Config) -> Result<Box<dyn Embedder>> {
             .with_max_retries(settings.max_retries)
             .with_max_concurrent(settings.max_concurrent)
             .with_query_prefix(config.embedder.query_prefix.clone())
-            .with_passage_prefix(config.embedder.passage_prefix.clone());
+            .with_passage_prefix(config.embedder.passage_prefix.clone())
+            .with_truncate(settings.truncate);
         Ok(Box::new(embedder))
     } else {
         Err(MinSyncError::Config(format!("unknown embedder id: {id}")))

--- a/src/embedder/retry.rs
+++ b/src/embedder/retry.rs
@@ -81,11 +81,25 @@ impl RetryPolicy {
 /// non-success statuses (auth, validation) are fatal.
 pub fn classify_status(status: reqwest::StatusCode, provider: &str, body: &str) -> RequestError {
     let message = format!("{provider} API error {status}: {body}");
+    if is_context_length_error(body) {
+        return RequestError::Fatal(format!(
+            "chunk exceeds the embedding model's context; \
+             lower `chunker.options.max_chunk_size` or set `embedder.truncate = true` \
+             ({message})"
+        ));
+    }
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
         RequestError::Retryable(message)
     } else {
         RequestError::Fatal(message)
     }
+}
+
+fn is_context_length_error(body: &str) -> bool {
+    let body = body.to_ascii_lowercase();
+    body.contains("context length")
+        || body.contains("input length exceeds")
+        || body.contains("must have less than")
 }
 
 /// Classify a request transport error: connection failures and timeouts are
@@ -185,6 +199,20 @@ mod tests {
         let error = result.unwrap_err();
         assert!(error.to_string().contains("401 unauthorized"));
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_context_length_server_error_is_fatal() {
+        let error = classify_status(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "TEI",
+            "the input length exceeds the context length",
+        );
+
+        assert!(matches!(error, RequestError::Fatal(message) if
+            message.contains("chunk exceeds the embedding model's context") &&
+            message.contains("chunker.options.max_chunk_size") &&
+            message.contains("embedder.truncate")));
     }
 
     #[tokio::test]

--- a/src/embedder/tei.rs
+++ b/src/embedder/tei.rs
@@ -15,6 +15,7 @@ pub struct TeiEmbedder {
     retry: RetryPolicy,
     query_prefix: Option<String>,
     passage_prefix: Option<String>,
+    truncate: bool,
     client: reqwest::Client,
 }
 
@@ -22,7 +23,7 @@ pub struct TeiEmbedder {
 struct EmbedRequest {
     inputs: Vec<String>,
     normalize: bool,
-    truncate: Option<()>,
+    truncate: Option<bool>,
 }
 
 impl TeiEmbedder {
@@ -39,6 +40,7 @@ impl TeiEmbedder {
             retry: RetryPolicy::default(),
             query_prefix: None,
             passage_prefix: None,
+            truncate: false,
             client: build_client(DEFAULT_REQUEST_TIMEOUT),
         }
     }
@@ -74,6 +76,11 @@ impl TeiEmbedder {
         self
     }
 
+    pub fn with_truncate(mut self, truncate: bool) -> Self {
+        self.truncate = truncate;
+        self
+    }
+
     async fn embed_inputs(&self, inputs: Vec<String>) -> Result<Vec<Vec<f32>>> {
         let expected_count = inputs.len();
         self.retry
@@ -81,7 +88,7 @@ impl TeiEmbedder {
                 let request = EmbedRequest {
                     inputs: inputs.clone(),
                     normalize: true,
-                    truncate: None,
+                    truncate: self.truncate.then_some(true),
                 };
 
                 let response = self
@@ -259,18 +266,50 @@ mod tests {
 
         Mock::given(method("POST"))
             .and(path("/embed"))
-            .respond_with(ResponseTemplate::new(500).set_body_string("server error"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_string("the input length exceeds the context length"),
+            )
+            .expect(1)
             .mount(&server)
             .await;
 
-        let embedder = fast_retry_embedder(&server.uri(), 0);
+        let embedder = fast_retry_embedder(&server.uri(), 3);
         let texts = vec!["hello".to_string()];
 
         let error = embedder.embed(&texts).await.unwrap_err();
 
         assert!(matches!(error, MinSyncError::Embedding(_)));
-        assert!(error.to_string().contains("TEI API error 500"));
-        assert!(error.to_string().contains("server error"));
+        assert!(error
+            .to_string()
+            .contains("chunk exceeds the embedding model's context"));
+        assert!(error.to_string().contains("chunker.options.max_chunk_size"));
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_truncate_option_is_sent_to_tei() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/embed"))
+            .and(body_json(json!({
+                "inputs": ["hello"],
+                "normalize": true,
+                "truncate": true
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([[0.1]])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let embedder = TeiEmbedder::new("intfloat/multilingual-e5-small", &server.uri(), 10)
+            .with_truncate(true);
+
+        assert_eq!(
+            embedder.embed(&["hello".to_string()]).await.unwrap(),
+            vec![vec![0.1]]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- classify context-length failures as fatal instead of retrying identical requests
- provide actionable chunk-size/truncation guidance for TEI-compatible embedders
- add opt-in `embedder.truncate = true` passthrough and regression coverage

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- real CLI QA against local HTTP 500/200 TEI fixtures

Closes #39