### PR TITLE
fix: return actionable CLI errors for invalid state

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@
 //! logging, dispatch here, and map errors to exit codes.
 
 use crate::cli::{Cli, Commands, OutputFormat, QueryMode};
+use crate::error::MinSyncError;
 use crate::error::Result;
 use crate::sync::MinSync;
 use std::path::PathBuf;
@@ -93,6 +94,7 @@ async fn sync(
     wait: bool,
     batch_size: Option<usize>,
 ) -> Result<()> {
+    require_initialized(minsync_dir)?;
     let ms = MinSync::new(root.clone());
     let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), wait)?;
     let mut config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
@@ -157,6 +159,7 @@ async fn query(
     k: usize,
     mode: QueryMode,
 ) -> Result<()> {
+    require_initialized(minsync_dir)?;
     let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     let store_path = crate::sync::collection_store_path(minsync_dir, &config.collection.path)?;
@@ -230,6 +233,7 @@ async fn status(format: &OutputFormat, minsync_dir: &std::path::Path) -> Result<
 }
 
 async fn check(format: &OutputFormat, minsync_dir: &std::path::Path) -> Result<()> {
+    require_initialized(minsync_dir)?;
     let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     let embedder = crate::embedder::create_embedder(&config)?;
@@ -271,6 +275,7 @@ async fn verify(
     all: bool,
     sample: usize,
 ) -> Result<()> {
+    require_initialized(minsync_dir)?;
     let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     let chunker = crate::chunker::create_chunker(&config)?;
@@ -302,7 +307,13 @@ async fn verify(
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
     }
-    Ok(())
+    if result.all_passed {
+        Ok(())
+    } else {
+        Err(MinSyncError::Other(
+            "verification failed — run `minsync verify --fix` to repair".to_string(),
+        ))
+    }
 }
 
 async fn watch(
@@ -312,6 +323,7 @@ async fn watch(
     debounce_ms: Option<u64>,
     watch_on_sync_error: bool,
 ) -> Result<()> {
+    require_initialized(minsync_dir)?;
     let _lock = crate::state::FileLock::acquire(&minsync_dir.join("lock"), false)?;
     let config = crate::config::Config::load(&minsync_dir.join("config.toml"))?;
     let chunker = crate::chunker::create_chunker(&config)?;
@@ -340,5 +352,12 @@ async fn watch(
         },
     )
     .await?;
+    Ok(())
+}
+
+fn require_initialized(minsync_dir: &std::path::Path) -> Result<()> {
+    if !minsync_dir.join("config.toml").exists() {
+        return Err(MinSyncError::NotInitialized);
+    }
     Ok(())
 }

--- a/tests/bm25_cli_e2e.rs
+++ b/tests/bm25_cli_e2e.rs
@@ -93,3 +93,63 @@ fn init_cli_persists_multilingual_language_option() {
         Config::load(&root.path().join(".minsync/config.toml")).expect("load initialized config");
     assert_eq!(config.lexical.language, "multilingual");
 }
+
+#[test]
+fn uninitialized_commands_report_not_initialized() {
+    let root = tempfile::tempdir().expect("create workspace");
+
+    for args in [
+        vec!["query", "alpha", "--mode", "bm25"],
+        vec!["check"],
+        vec!["verify"],
+        vec!["watch"],
+    ] {
+        let output = Command::cargo_bin("minsync")
+            .expect("find minsync binary")
+            .current_dir(root.path())
+            .args(&args)
+            .output()
+            .expect("run command");
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "command {:?} should fail with a user error",
+            args
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("not initialized"),
+            "command {:?} should explain initialization requirement; stderr={stderr:?}",
+            args
+        );
+        assert!(
+            !root.path().join(".minsync/lock").exists(),
+            "command {:?} should not create state in an uninitialized workspace",
+            args
+        );
+    }
+}
+
+#[test]
+fn verify_failure_returns_nonzero_exit_code() {
+    let root = tempfile::tempdir().expect("create workspace");
+    Command::cargo_bin("minsync")
+        .expect("find minsync binary")
+        .current_dir(root.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("minsync")
+        .expect("find minsync binary")
+        .current_dir(root.path())
+        .args(["--format", "json", "verify"])
+        .output()
+        .expect("run verify");
+
+    assert_eq!(output.status.code(), Some(1));
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse verification result");
+    assert_eq!(result["all_passed"], false);
+}


### PR DESCRIPTION
## Summary
- report `not initialized` before creating lock/state files
- make `verify` return exit code 1 when checks fail
- add CLI E2E regression coverage for both behaviors

## Verification
- `cargo test --all-targets --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- manual CLI QA for help, init, status, dry-run, invalid state, and failed verify

## Notes
- Existing untracked `.gjc/` and `review-comment.md` were left untouched.
- macOS emits a non-fatal linker warning about `__eh_frame` size.
