### PR TITLE
feat: default to local EmbeddingGemma embeddings

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -39,13 +39,14 @@ cd MinSync
 cargo build --release
 ```
 
+MinSync는 기본적으로 로컬 [EmbeddingGemma](https://huggingface.co/google/embeddinggemma-300m) 모델로 embedding하므로 API key가 필요 없습니다. 첫 sync 전에 아래 [TEI 설정](#tei로-로컬-embedding-사용하기)대로 로컬 TEI 서버를 실행하세요.
+
 OpenAI embedding을 사용할 경우:
 
 ```bash
 export OPENAI_API_KEY="sk-..."
+minsync init --embedder openai:text-embedding-3-small
 ```
-
-로컬 embedding은 아래 TEI 설정을 참고하세요.
 
 ## 빠른 시작
 
@@ -172,15 +173,16 @@ MinSync는 기본적으로 embedded LanceDB에 vector를 저장합니다.
 id = "lancedb"
 
 [vectorstore.options]
-dimension = 1536
+dimension = 768
 index_build_threshold = 256
 index_optimize_delta_threshold = 10000
 ```
 
-사용하는 embedder에 맞게 `dimension`을 설정하세요.
+`minsync init`은 알려진 embedder에 대해 `dimension`을 자동으로 설정합니다. 다른 모델을 사용할 경우 embedder에 맞게 `dimension`을 설정하세요.
 
 | Embedder | Dimension |
 |---|---:|
+| `tei:google/embeddinggemma-300m` (기본값) | 768 |
 | `openai:text-embedding-3-small` | 1536 |
 | `tei:intfloat/multilingual-e5-small` | 384 |
 | `tei:BAAI/bge-m3` | 1024 |
@@ -204,21 +206,30 @@ max_concurrent = 1
 
 ## TEI로 로컬 Embedding 사용하기
 
-Hugging Face Text Embeddings Inference를 설치하고 실행합니다.
+기본 embedder `tei:google/embeddinggemma-300m`은 Hugging Face Text Embeddings Inference를 통해 전체가 로컬 머신에서 실행됩니다. EmbeddingGemma는 Hugging Face에서 gated 모델이므로 모델 페이지에서 약관에 한 번 동의한 뒤 token을 export하세요.
 
 ```bash
 brew install text-embeddings-inference
-text-embeddings-router --model-id intfloat/multilingual-e5-small --port 8080 --dtype float32
+export HF_TOKEN="hf_..."   # https://huggingface.co/google/embeddinggemma-300m 약관 동의 후
+text-embeddings-router --model-id google/embeddinggemma-300m --port 8080 --dtype float32
 curl http://localhost:8080/health
 ```
 
-MinSync 설정:
+EmbeddingGemma는 float16을 지원하지 않으므로 `--dtype float32`(또는 `bfloat16`)를 유지하세요.
+
+`minsync init`은 이미 이 모델을 대상으로 합니다. 생성되는 `config.toml`에 EmbeddingGemma retrieval prompt와 `dimension = 768`이 포함되어 있어 수정 없이 indexing과 query가 동작합니다.
+
+```bash
+minsync init
+minsync sync
+minsync query "검색어" --k 5
+```
+
+다른 TEI 모델을 사용하려면 init 시점에 id를 넘기고 `.minsync/config.toml`에서 dimension과 prompt prefix를 설정하세요.
 
 ```bash
 minsync init --embedder tei:intfloat/multilingual-e5-small
 ```
-
-`.minsync/config.toml`:
 
 ```toml
 [embedder]
@@ -229,13 +240,6 @@ passage_prefix = "passage: "
 
 [vectorstore.options]
 dimension = 384
-```
-
-실행:
-
-```bash
-minsync sync --full
-minsync query "검색어" --k 5
 ```
 
 ## Ignoring Files

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ cd MinSync
 cargo build --release
 ```
 
-For OpenAI embeddings:
+MinSync embeds with a local [EmbeddingGemma](https://huggingface.co/google/embeddinggemma-300m) model by default, so no API key is required. Start the local TEI server from the [setup below](#local-embeddings-with-hugging-face-tei) before your first sync.
+
+For OpenAI embeddings instead:
 
 ```bash
 export OPENAI_API_KEY="sk-..."
+minsync init --embedder openai:text-embedding-3-small
 ```
-
-For local embeddings, use the TEI setup below.
 
 ## Quick Start
 
@@ -202,15 +203,16 @@ MinSync stores vectors in embedded LanceDB by default:
 id = "lancedb"
 
 [vectorstore.options]
-dimension = 1536
+dimension = 768
 index_build_threshold = 256
 index_optimize_delta_threshold = 10000
 ```
 
-Set `dimension` to match your embedder:
+`minsync init` sets `dimension` automatically for known embedders. For other models, set `dimension` to match your embedder:
 
 | Embedder | Dimension |
 |---|---:|
+| `tei:google/embeddinggemma-300m` (default) | 768 |
 | `openai:text-embedding-3-small` | 1536 |
 | `tei:intfloat/multilingual-e5-small` | 384 |
 | `tei:BAAI/bge-m3` | 1024 |
@@ -234,21 +236,30 @@ max_concurrent = 1
 
 ## Local Embeddings with TEI
 
-Install and launch Hugging Face Text Embeddings Inference:
+The default embedder `tei:google/embeddinggemma-300m` runs entirely on your machine through Hugging Face Text Embeddings Inference. EmbeddingGemma is gated on Hugging Face: accept the terms on the model page once, then export a token.
 
 ```bash
 brew install text-embeddings-inference
-text-embeddings-router --model-id intfloat/multilingual-e5-small --port 8080 --dtype float32
+export HF_TOKEN="hf_..."   # after accepting https://huggingface.co/google/embeddinggemma-300m terms
+text-embeddings-router --model-id google/embeddinggemma-300m --port 8080 --dtype float32
 curl http://localhost:8080/health
 ```
 
-Configure MinSync:
+EmbeddingGemma does not support float16, so keep `--dtype float32` (or `bfloat16`).
+
+`minsync init` already targets this model: the generated `config.toml` carries the EmbeddingGemma retrieval prompts and `dimension = 768`, so indexing and querying work without edits:
+
+```bash
+minsync init
+minsync sync
+minsync query "검색어" --k 5
+```
+
+To serve another TEI model, pass it at init time and set its dimension and prompt prefixes in `.minsync/config.toml`:
 
 ```bash
 minsync init --embedder tei:intfloat/multilingual-e5-small
 ```
-
-Then set the LanceDB dimension and TEI prefixes:
 
 ```toml
 [embedder]
@@ -259,13 +270,6 @@ passage_prefix = "passage: "
 
 [vectorstore.options]
 dimension = 384
-```
-
-Run:
-
-```bash
-minsync sync --full
-minsync query "검색어" --k 5
 ```
 
 ## Ignoring Files
@@ -291,7 +295,7 @@ MinSync ships a Vercel Agent Skill for coding agents that need to add incrementa
 npx skills add github:NomaDamas/MinSync/skills/minsync
 ```
 
-The skill tells agents how to install MinSync, initialize `.minsync/`, choose OpenAI or local TEI embeddings, ignore binary files, and star the repository with `gh repo star NomaDamas/MinSync` during installation when policy and credentials allow it.
+The skill tells agents how to install MinSync, initialize `.minsync/`, use the default local EmbeddingGemma embeddings or configure OpenAI, ignore binary files, and star the repository with `gh repo star NomaDamas/MinSync` during installation when policy and credentials allow it.
 
 ## Release Checklist
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -34,7 +34,7 @@ Current provider prefixes:
 - `openai:` for OpenAI-compatible embeddings.
 - `tei:` for Hugging Face Text Embeddings Inference.
 
-Default model: `openai:text-embedding-3-small`.
+Default model: `tei:google/embeddinggemma-300m` served by a local TEI-compatible server (dimension 768; the default config carries the EmbeddingGemma retrieval prompt prefixes).
 
 To add a provider:
 

--- a/skills/minsync/SKILL.md
+++ b/skills/minsync/SKILL.md
@@ -62,6 +62,16 @@ node_modules/
 
 ## Choose Embeddings
 
+Local EmbeddingGemma (default, no API key):
+
+```bash
+export HF_TOKEN="hf_..."   # after accepting https://huggingface.co/google/embeddinggemma-300m terms
+text-embeddings-router --model-id google/embeddinggemma-300m --port 8080 --dtype float32
+minsync init
+```
+
+The default config already carries the EmbeddingGemma retrieval prompts and `dimension = 768`.
+
 OpenAI:
 
 ```bash
@@ -69,7 +79,7 @@ export OPENAI_API_KEY="sk-..."
 minsync init --embedder openai:text-embedding-3-small
 ```
 
-Local TEI:
+Other TEI models, for example e5-small:
 
 ```bash
 text-embeddings-router --model-id intfloat/multilingual-e5-small --port 8080 --dtype float32
@@ -115,7 +125,7 @@ Use this checklist when adding an embedding provider or model family:
 6. Document the model dimension and tell agents to update `[vectorstore.options].dimension`, then run `minsync sync --full`.
 7. Add tests for prefix stripping, batching, retryable errors, fatal errors, timeout retry, and query/document prefix behavior.
 
-The default embedder is `openai:text-embedding-3-small` with dimension `1536`. TEI models are supported with ids like `tei:intfloat/multilingual-e5-small` and `tei:BAAI/bge-m3`.
+The default embedder is `tei:google/embeddinggemma-300m` with dimension `768`, served by a local TEI-compatible server with no API key. OpenAI is supported with ids like `openai:text-embedding-3-small`, and other TEI models with ids like `tei:intfloat/multilingual-e5-small` and `tei:BAAI/bge-m3`.
 
 For a longer implementation checklist, read `docs/EXTENDING.md` in the MinSync repository.
 
@@ -144,6 +154,6 @@ Run `minsync sync` after edits. It re-embeds only changed chunks and sweeps stal
 ## Troubleshooting
 
 - `not initialized`: run `minsync init`.
-- `OPENAI_API_KEY` missing: export it or use TEI.
+- Embedding request fails: make sure the local TEI server is running for the default embedder, or export `OPENAI_API_KEY` when using an `openai:` embedder.
 - Vector dimension mismatch: set `[vectorstore.options].dimension` to the embedder dimension and run `minsync sync --full`.
 - Binary files appear empty: this is expected; MinSync only reads UTF-8 text.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,7 +45,7 @@ pub enum Commands {
     Init {
         #[arg(long)]
         force: bool,
-        #[arg(long, default_value = "openai:text-embedding-3-small")]
+        #[arg(long, default_value = crate::config::DEFAULT_EMBEDDER_ID)]
         embedder: String,
         #[arg(long, default_value = "recursive")]
         chunker: String,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,24 +50,49 @@ mod tests {
         assert_eq!(config.chunker.id, "recursive");
         assert_eq!(config.chunker.options.max_chunk_size, 4096);
         assert_eq!(config.chunker.options.delimiters, "\n.?!");
-        assert_eq!(config.embedder.id, "openai:text-embedding-3-small");
+        assert_eq!(config.embedder.id, DEFAULT_EMBEDDER_ID);
         assert_eq!(config.embedder.batch_size, 64);
         assert_eq!(config.embedder.max_concurrent, 1);
         assert_eq!(config.embedder.max_retries, 3);
         assert_eq!(config.embedder.timeout_seconds, 60);
         assert_eq!(config.embedder.base_url, None);
-        assert_eq!(config.embedder.query_prefix, None);
-        assert_eq!(config.embedder.passage_prefix, None);
+        assert_eq!(
+            config.embedder.query_prefix.as_deref(),
+            Some(EMBEDDINGGEMMA_QUERY_PREFIX)
+        );
+        assert_eq!(
+            config.embedder.passage_prefix.as_deref(),
+            Some(EMBEDDINGGEMMA_PASSAGE_PREFIX)
+        );
         assert_eq!(config.vectorstore.id, "lancedb");
         assert_eq!(config.lexical.language, "simple");
         assert_eq!(
             config.vectorstore.options["dimension"].as_integer(),
-            Some(1536)
+            Some(768)
         );
         assert!(config.normalize.strip_trailing_whitespace);
         assert!(config.normalize.normalize_newlines);
         assert!(!config.normalize.collapse_whitespace);
         assert!(!config.normalize.strip_frontmatter);
+    }
+
+    #[test]
+    fn test_known_embedding_dimension() {
+        assert_eq!(known_embedding_dimension(DEFAULT_EMBEDDER_ID), Some(768));
+        assert_eq!(
+            known_embedding_dimension("openai:text-embedding-3-small"),
+            Some(1536)
+        );
+        assert_eq!(
+            known_embedding_dimension("openai:text-embedding-3-large"),
+            Some(3072)
+        );
+        assert_eq!(
+            known_embedding_dimension("tei:intfloat/multilingual-e5-small"),
+            Some(384)
+        );
+        assert_eq!(known_embedding_dimension("tei:BAAI/bge-m3"), Some(1024));
+        assert_eq!(known_embedding_dimension("tei:custom/model"), None);
     }
 
     #[test]

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -111,8 +111,32 @@ fn default_timeout_seconds() -> u64 {
     60
 }
 
+/// Default embedder: Google EmbeddingGemma served by a local
+/// TEI-compatible server, so fresh indexes need no API credentials.
+pub const DEFAULT_EMBEDDER_ID: &str = "tei:google/embeddinggemma-300m";
+
+/// EmbeddingGemma retrieval prompt for queries (see the model card).
+pub const EMBEDDINGGEMMA_QUERY_PREFIX: &str = "task: search result | query: ";
+
+/// EmbeddingGemma retrieval prompt for documents without a title.
+pub const EMBEDDINGGEMMA_PASSAGE_PREFIX: &str = "title: none | text: ";
+
+/// Known embedding output dimension for embedder ids MinSync recognizes.
+/// Unknown models return `None`; set `[vectorstore.options].dimension`
+/// manually for those.
+pub fn known_embedding_dimension(embedder_id: &str) -> Option<usize> {
+    match embedder_id {
+        "tei:google/embeddinggemma-300m" => Some(768),
+        "openai:text-embedding-3-small" | "openai:text-embedding-ada-002" => Some(1536),
+        "openai:text-embedding-3-large" => Some(3072),
+        "tei:intfloat/multilingual-e5-small" => Some(384),
+        "tei:BAAI/bge-m3" => Some(1024),
+        _ => None,
+    }
+}
+
 /// For `vectorstore.id = "lancedb"`, `options.dimension` sets the embedding
-/// dimension (default 1536 for `openai:text-embedding-3-small`).
+/// dimension (default 768 for `tei:google/embeddinggemma-300m`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VectorStoreConfig {
     pub id: String,
@@ -126,7 +150,7 @@ fn default_vectorstore_options() -> toml::Value {
 
 fn default_lancedb_options() -> toml::Value {
     let mut table = toml::map::Map::new();
-    table.insert("dimension".to_string(), toml::Value::Integer(1536));
+    table.insert("dimension".to_string(), toml::Value::Integer(768));
     toml::Value::Table(table)
 }
 
@@ -173,14 +197,14 @@ impl Config {
                 options: ChunkerOptions::default(),
             },
             embedder: EmbedderConfig {
-                id: "openai:text-embedding-3-small".to_string(),
+                id: DEFAULT_EMBEDDER_ID.to_string(),
                 batch_size: default_batch_size(),
                 max_concurrent: default_max_concurrent(),
                 max_retries: default_max_retries(),
                 timeout_seconds: default_timeout_seconds(),
                 base_url: None,
-                query_prefix: None,
-                passage_prefix: None,
+                query_prefix: Some(EMBEDDINGGEMMA_QUERY_PREFIX.to_string()),
+                passage_prefix: Some(EMBEDDINGGEMMA_PASSAGE_PREFIX.to_string()),
                 truncate: false,
             },
             vectorstore: VectorStoreConfig {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -54,6 +54,15 @@ impl MinSync {
         let mut config = Config::default_for(&source_id);
         config.embedder.id = embedder_id.to_string();
         config.chunker.id = chunker_id.to_string();
+        if embedder_id != crate::config::DEFAULT_EMBEDDER_ID {
+            // The EmbeddingGemma prompts from the default config only apply to
+            // the default model.
+            config.embedder.query_prefix = None;
+            config.embedder.passage_prefix = None;
+        }
+        if let Some(dimension) = crate::config::known_embedding_dimension(embedder_id) {
+            config.vectorstore.options["dimension"] = toml::Value::Integer(dimension as i64);
+        }
 
         config.save(&self.minsync_dir.join("config.toml"))?;
         Manifest::scan(&self.root, &source_id)?.save(&self.minsync_dir.join("manifest.json"))?;
@@ -385,6 +394,61 @@ mod tests {
         assert!(sync.minsync_dir.join("config.toml").exists());
         assert!(sync.minsync_dir.join("manifest.json").exists());
         assert_eq!(config.version, 1);
+    }
+
+    #[test]
+    fn test_init_applies_embeddinggemma_defaults() {
+        let (_dir, sync, _chunker, _embedder, _store) = fixture();
+
+        let config = sync
+            .init(false, crate::config::DEFAULT_EMBEDDER_ID, "recursive")
+            .expect("init succeeds");
+
+        assert_eq!(config.embedder.id, "tei:google/embeddinggemma-300m");
+        assert_eq!(
+            config.embedder.query_prefix.as_deref(),
+            Some(crate::config::EMBEDDINGGEMMA_QUERY_PREFIX)
+        );
+        assert_eq!(
+            config.embedder.passage_prefix.as_deref(),
+            Some(crate::config::EMBEDDINGGEMMA_PASSAGE_PREFIX)
+        );
+        assert_eq!(
+            config.vectorstore.options["dimension"].as_integer(),
+            Some(768)
+        );
+    }
+
+    #[test]
+    fn test_init_maps_known_embedder_dimension_and_clears_prefixes() {
+        let (_dir, sync, _chunker, _embedder, _store) = fixture();
+
+        let config = sync
+            .init(false, "openai:text-embedding-3-small", "recursive")
+            .expect("init succeeds");
+
+        assert_eq!(
+            config.vectorstore.options["dimension"].as_integer(),
+            Some(1536)
+        );
+        assert_eq!(config.embedder.query_prefix, None);
+        assert_eq!(config.embedder.passage_prefix, None);
+    }
+
+    #[test]
+    fn test_init_unknown_embedder_keeps_default_dimension() {
+        let (_dir, sync, _chunker, _embedder, _store) = fixture();
+
+        let config = sync
+            .init(false, "tei:custom/model", "recursive")
+            .expect("init succeeds");
+
+        assert_eq!(
+            config.vectorstore.options["dimension"].as_integer(),
+            Some(768)
+        );
+        assert_eq!(config.embedder.query_prefix, None);
+        assert_eq!(config.embedder.passage_prefix, None);
     }
 
     #[test]


### PR DESCRIPTION
## Why

MinSync defaulted to `openai:text-embedding-3-small`, so a fresh `minsync init && minsync sync` required an OpenAI API key and sent all content to a remote API. [EmbeddingGemma](https://huggingface.co/google/embeddinggemma-300m) (300M, 768-dim, 2048-token context, 100+ languages) runs locally and lightly on any machine through the TEI-compatible server MinSync already supports — no credentials, no per-request cost, no data leaving the machine.

## What changes

- **Default embedder**: `Config::default_for` now targets `tei:google/embeddinggemma-300m` at the TEI default address (`http://localhost:8080`), with the model card's retrieval prompts baked in (`task: search result | query: ` for queries, `title: none | text: ` for passages) and LanceDB `dimension = 768`. `minsync init` (via `DEFAULT_EMBEDDER_ID`) picks this up with no flags.
- **Coherent init for other models**: `minsync init --embedder <id>` now maps known ids to their output dimension (`openai:text-embedding-3-small`/`ada-002` → 1536, `text-embedding-3-large` → 3072, `tei:intfloat/multilingual-e5-small` → 384, `tei:BAAI/bge-m3` → 1024) and clears the EmbeddingGemma prompt prefixes for non-default models. Previously, non-default embedders silently kept the default dimension, which broke the first sync until `config.toml` was hand-edited.
- **Docs**: README/README.ko document the local-first setup (HF token for the gated model download, `--dtype float32` since EmbeddingGemma does not support float16), the dimension table gains the 768 default row, and `docs/EXTENDING.md` + `skills/minsync/SKILL.md` state the new default.

## Compatibility

- Existing `.minsync/config.toml` files are untouched — the change only affects newly initialized workspaces.
- The `openai:` provider stays fully supported behind `--embedder openai:...` + `OPENAI_API_KEY`, now with the correct dimension written at init time.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo test`: full suite passes, including new unit tests for the default config, the dimension mapping, and init behavior for default/known/unknown embedders.
- Smoke test: `minsync init` in a fresh directory generates `config.toml` with `id = "tei:google/embeddinggemma-300m"`, both EmbeddingGemma prefixes, and `dimension = 768`.
